### PR TITLE
Support historical invalid byte representation of zero

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,12 @@ All notable changes to casper-js-sdk.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/), and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## 2.6.1
+
+### Fixed
+
+- Added workaround for historical deploys with invalid serialized `0`.
+
 ## 2.6.0
 
 ### Added

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "casper-js-sdk",
-  "version": "2.6.0",
+  "version": "2.6.1",
   "license": "Apache 2.0",
   "description": "SDK to interact with the Casper blockchain",
   "homepage": "https://github.com/casper-ecosystem/casper-js-sdk#README.md",

--- a/src/lib/ByteConverters.ts
+++ b/src/lib/ByteConverters.ts
@@ -7,14 +7,12 @@ import { BigNumber, BigNumberish } from '@ethersproject/bignumber';
 import { MaxUint256, NegativeOne, One, Zero } from '@ethersproject/constants';
 import { arrayify, concat } from '@ethersproject/bytes';
 import { CLValue, CLValueParsers, ToBytes } from './CLValue';
-import { arrayEquals } from './DeployUtil';
 
 /**
  * Convert number to bytes
  */
 export const toBytesNumber = (bitSize: number, signed: boolean) => (
-  value: BigNumberish,
-  originalBytes?: Uint8Array
+  value: BigNumberish
 ): Uint8Array => {
   const val = BigNumber.from(value);
 
@@ -39,13 +37,6 @@ export const toBytesNumber = (bitSize: number, signed: boolean) => (
     if (bitSize > 64) {
       // if zero just return zero
       if (valTwos.eq(0)) {
-        // NOTE: this is for historicial deploys that had zero represented as `0100`.
-        if (
-          originalBytes &&
-          arrayEquals(originalBytes, Uint8Array.from([1, 0]))
-        ) {
-          return originalBytes;
-        }
         return bytes;
       }
       // for u128, u256, u512, we have to and append extra byte for length

--- a/src/lib/ByteConverters.ts
+++ b/src/lib/ByteConverters.ts
@@ -7,10 +7,7 @@ import { BigNumber, BigNumberish } from '@ethersproject/bignumber';
 import { MaxUint256, NegativeOne, One, Zero } from '@ethersproject/constants';
 import { arrayify, concat } from '@ethersproject/bytes';
 import { CLValue, CLValueParsers, ToBytes } from './CLValue';
-
-const arrayEquals = (a: Uint8Array, b: Uint8Array): boolean => {
-  return a.length === b.length && a.every((val, index) => val === b[index]);
-};
+import { arrayEquals } from './DeployUtil';
 
 /**
  * Convert number to bytes

--- a/src/lib/CLValue/Numeric.ts
+++ b/src/lib/CLValue/Numeric.ts
@@ -21,16 +21,22 @@ import {
   U256_ID,
   U512_ID
 } from './constants';
+import { arrayEquals } from '../DeployUtil';
 
 abstract class NumericBytesParser extends CLValueBytesParsers {
   toBytes(value: Numeric): ToBytesResult {
-    const result = Ok(
-      toBytesNumber(value.bitSize, value.signed)(
-        value.data,
-        value.originalBytes
-      )
-    );
-    return result;
+    // NOTE: this is for historicial deploys that had zero represented as `0100`.
+    if (
+      (value.bitSize === 128 ||
+        value.bitSize === 256 ||
+        value.bitSize === 512) &&
+      value.originalBytes &&
+      arrayEquals(value.originalBytes, Uint8Array.from([1, 0]))
+    ) {
+      return Ok(value.originalBytes);
+    }
+
+    return Ok(toBytesNumber(value.bitSize, value.signed)(value.data));
   }
 }
 

--- a/src/lib/CLValue/Numeric.ts
+++ b/src/lib/CLValue/Numeric.ts
@@ -26,6 +26,7 @@ import { arrayEquals } from '../DeployUtil';
 abstract class NumericBytesParser extends CLValueBytesParsers {
   toBytes(value: Numeric): ToBytesResult {
     // NOTE: this is for historicial deploys that had zero represented as `0100`.
+    // If there is zero in form of `0100` insted of `00` it should be serialized the same way to prevent changes in bodyHash.
     if (
       (value.bitSize === 128 ||
         value.bitSize === 256 ||
@@ -42,8 +43,7 @@ abstract class NumericBytesParser extends CLValueBytesParsers {
 
 abstract class Numeric extends CLValue {
   data: BigNumber;
-  // Note: Original bytes are only used for legacy purposes.
-  // If there is zero in form of `0100` insted of `00` it should be serialized the same way to prevent changes in bodyHash.
+  // NOTE: Original bytes are only used for legacy purposes.
   originalBytes?: Uint8Array;
   bitSize: number;
   signed: boolean;

--- a/src/lib/DeployUtil.ts
+++ b/src/lib/DeployUtil.ts
@@ -1231,7 +1231,7 @@ export const validateDeploy = (deploy: Deploy): Result<Deploy, string> => {
   return Ok(deploy);
 };
 
-const arrayEquals = (a: Uint8Array, b: Uint8Array): boolean => {
+export const arrayEquals = (a: Uint8Array, b: Uint8Array): boolean => {
   return a.length === b.length && a.every((val, index) => val === b[index]);
 };
 

--- a/test/lib/byterepr.test.ts
+++ b/test/lib/byterepr.test.ts
@@ -119,7 +119,7 @@ describe(`numbers' toBytes`, () => {
     ).unwrap();
     const clValBytes = CLValueParsers.toBytes(clVal).unwrap();
 
-    expect(clValFromBytes).to.deep.eq(clVal);
+    expect(clValFromBytes.value()).to.deep.eq(clVal.value());
     expect(clValBytes).to.deep.eq(validBytes);
   });
 


### PR DESCRIPTION
Added workaround for `U128`, `U256` and `U512` which stores inside the structure bytes used for deserialization, and if structure is unchanged it serializes again to the original bytes. This prevents invalid `bodyHash` problem while validating historical deploys from the network.

fixes #103 @KillianH