### PR TITLE
casper-js-sdk 2.7.8

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,13 @@ All notable changes to casper-js-sdk.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/), and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## 2.7.6
+## 2.7.8
+
+### Fixed
+
+- Fixed problems with deserialization Tuples containing CLType which includes length parameter (eg. CLByteArray).
+
+## 2.7.7
 
 ### Changed
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "casper-js-sdk",
-  "version": "2.7.7",
+  "version": "2.7.8",
   "license": "Apache 2.0",
   "description": "SDK to interact with the Casper blockchain",
   "homepage": "https://github.com/casper-ecosystem/casper-js-sdk#README.md",
@@ -31,7 +31,7 @@
     "BlockChain",
     "sdk"
   ],
-  "author": "AbnerZheng <abner@casper.io>",
+  "author": "Jan Hoffmann <jan@casperlabs.io>",
   "lint-staged": {
     "src/**/*.{ts,tsx}": [
       "eslint --fix",

--- a/src/lib/CLValue/Tuple.test.ts
+++ b/src/lib/CLValue/Tuple.test.ts
@@ -7,6 +7,7 @@ import {
   CLTuple1Type,
   CLTuple2Type,
   CLTuple3Type,
+  CLByteArray,
   CLI32,
   CLI32Type,
   CLBool,
@@ -113,6 +114,47 @@ describe('CLTuple', () => {
         ])
       ).unwrap()
     ).to.be.deep.eq(myTup3);
+  });
+
+  it('fromJSON() / toJSON()', () => {
+    const arr = new CLByteArray(Uint8Array.from([1, 2, 3]));
+    const uint8 = new Uint8Array();
+    uint8.fill(1, 0, 32);
+    const arr2 = new CLByteArray(uint8);
+
+    const myTup1 = new CLTuple1([arr]);
+    const myTup2 = new CLTuple2([arr, arr2]);
+    const myTup3 = new CLTuple3([arr, arr2, new CLString('ABC')]);
+
+    const myTup1JSON = CLValueParsers.toJSON(myTup1).unwrap();
+    const expectedMyTup1JSON = JSON.parse(
+      `{"bytes":"010203","cl_type":{"Tuple1":[{"ByteArray":3}]}}`
+    );
+
+    const myTup2JSON = CLValueParsers.toJSON(myTup2).unwrap();
+    const expectedMyTup2JSON = JSON.parse(
+      `{"bytes":"010203","cl_type":{"Tuple2":[{"ByteArray":3},{"ByteArray":0}]}}`
+    );
+
+    const myTup3JSON = CLValueParsers.toJSON(myTup3).unwrap();
+    const expectedMyTup3JSON = JSON.parse(
+      `{"bytes":"01020303000000414243","cl_type":{"Tuple3":[{"ByteArray":3},{"ByteArray":0},"String"]}}`
+    );
+
+    expect(myTup1JSON).to.be.deep.eq(expectedMyTup1JSON);
+    expect(CLValueParsers.fromJSON(expectedMyTup1JSON).unwrap()).to.be.deep.eq(
+      myTup1
+    );
+
+    expect(myTup2JSON).to.be.deep.eq(expectedMyTup2JSON);
+    expect(CLValueParsers.fromJSON(expectedMyTup2JSON).unwrap()).to.be.deep.eq(
+      myTup2
+    );
+
+    expect(myTup3JSON).to.be.deep.eq(expectedMyTup3JSON);
+    expect(CLValueParsers.fromJSON(expectedMyTup3JSON).unwrap()).to.be.deep.eq(
+      myTup3
+    );
   });
 
   it('fromJSON() / toJSON()', () => {

--- a/src/lib/CLValue/Tuple.test.ts
+++ b/src/lib/CLValue/Tuple.test.ts
@@ -118,9 +118,44 @@ describe('CLTuple', () => {
 
   it('fromJSON() / toJSON()', () => {
     const arr = new CLByteArray(Uint8Array.from([1, 2, 3]));
-    const uint8 = new Uint8Array();
-    uint8.fill(1, 0, 32);
-    const arr2 = new CLByteArray(uint8);
+    const arr2 = new CLByteArray(
+      Uint8Array.from([
+        1,
+        2,
+        3,
+        4,
+        5,
+        6,
+        7,
+        8,
+        9,
+        10,
+        11,
+        12,
+        13,
+        14,
+        15,
+        16,
+        17,
+        18,
+        19,
+        20,
+        21,
+        22,
+        23,
+        24,
+        25,
+        26,
+        27,
+        28,
+        29,
+        30,
+        31,
+        32,
+        33,
+        34
+      ])
+    );
 
     const myTup1 = new CLTuple1([arr]);
     const myTup2 = new CLTuple2([arr, arr2]);
@@ -133,12 +168,12 @@ describe('CLTuple', () => {
 
     const myTup2JSON = CLValueParsers.toJSON(myTup2).unwrap();
     const expectedMyTup2JSON = JSON.parse(
-      `{"bytes":"010203","cl_type":{"Tuple2":[{"ByteArray":3},{"ByteArray":0}]}}`
+      `{"bytes":"0102030102030405060708090a0b0c0d0e0f101112131415161718191a1b1c1d1e1f202122","cl_type":{"Tuple2":[{"ByteArray":3},{"ByteArray":34}]}}`
     );
 
     const myTup3JSON = CLValueParsers.toJSON(myTup3).unwrap();
     const expectedMyTup3JSON = JSON.parse(
-      `{"bytes":"01020303000000414243","cl_type":{"Tuple3":[{"ByteArray":3},{"ByteArray":0},"String"]}}`
+      `{"bytes":"0102030102030405060708090a0b0c0d0e0f101112131415161718191a1b1c1d1e1f20212203000000414243","cl_type":{"Tuple3":[{"ByteArray":3},{"ByteArray":34},"String"]}}`
     );
 
     expect(myTup1JSON).to.be.deep.eq(expectedMyTup1JSON);

--- a/src/lib/CLValue/Tuple.ts
+++ b/src/lib/CLValue/Tuple.ts
@@ -60,7 +60,8 @@ export class CLTupleBytesParser extends CLValueBytesParsers {
     const val = type.inner.map((t: CLType) => {
       const parser = matchByteParserByCLType(t).unwrap();
       const { result: vRes, remainder: vRem } = parser.fromBytesWithRemainder(
-        rem
+        rem,
+        t
       );
 
       rem = vRem!;


### PR DESCRIPTION
## 2.7.8

### Fixed

- Fixed problems with deserialization Tuples containing CLType which includes length parameter (eg. CLByteArray).
