### PR TITLE
CI: Set registry in workflow

### DIFF
--- a/.github/workflows/publish-casper-client-sdk.yml
+++ b/.github/workflows/publish-casper-client-sdk.yml
@@ -23,6 +23,7 @@ jobs:
       uses: actions/setup-node@5b949b50c3461bbcd5a540b150c368278160234a #v3.4.0
       with:
         node-version: ${{ matrix.node-version }}
+        registry-url: 'https://registry.npmjs.org'
     - run: npm install
     - name: Publish to NPM
       run: npm publish --access public

--- a/package.json
+++ b/package.json
@@ -8,9 +8,6 @@
     "type": "git",
     "url": "https://github.com/casper-ecosystem/casper-js-sdk.git"
   },
-  "publishConfig": {
-    "registry": "https://registry.npmjs.org/"
-  },
   "main": "dist/lib.node.js",
   "browser": "dist/lib.js",
   "types": "dist/index.d.ts",


### PR DESCRIPTION
Moves registry from `package.json` to `setup-node` action
- see: https://docs.github.com/en/actions/publishing-packages/publishing-nodejs-packages#publishing-packages-to-the-npm-registry