### PR TITLE
Update exports from lib and stream service

### DIFF
--- a/src/lib/index.ts
+++ b/src/lib/index.ts
@@ -4,6 +4,7 @@ import * as Keys from './Keys';
 import * as Serialization from './Serialization';
 import * as Signer from './Signer';
 export * from './CLValue';
+export * from './StoredValue';
 export * from './RuntimeArgs';
 export * from './CasperClient';
 export * from './SignedMessage';

--- a/src/services/EventStream.ts
+++ b/src/services/EventStream.ts
@@ -108,7 +108,8 @@ export class EventStream {
   }
 
   public async start(eventId = 0) {
-    const requestUrl = `${this.eventStreamUrl}?start_from=${eventId}`;
+    const separator = this.eventStreamUrl.indexOf('?') > -1 ? '&' : '?';
+    const requestUrl = `${this.eventStreamUrl}${separator}start_from=${eventId}`;
     const response = await fetch(requestUrl);
     const body = await response.readable();
 

--- a/src/services/EventStream.ts
+++ b/src/services/EventStream.ts
@@ -1,7 +1,7 @@
 import { fetch } from 'fetch-h2';
 import { Result, Ok, Err } from 'ts-results';
 
-interface DeploySubscription {
+export interface DeploySubscription {
   deployHash: string;
   eventHandlerFn: EventHandlerFn;
 }
@@ -64,7 +64,7 @@ interface EventSubscription {
   eventHandlerFn: EventHandlerFn;
 }
 
-interface EventParseResult {
+export interface EventParseResult {
   id: string | null;
   err: StreamErrors | null;
   body: any | null;


### PR DESCRIPTION
I would like to change 3 things :

- Export `StoredValue` module wise because even it is already accessible you need to do 
```import { StoredValue } from 'casper-js-sdk/dist/lib/StoredValue';``` 
instead of 
```import { StoredValue } from 'casper-js-sdk';```

- Export ```DeploySubscription``` and ```EventParseResult``` because they are used in `DeployWatcher.subscribe(val: DeploySubscription[])` and `EventStream.subscribe` in order to be able to do in a Typescript app
```js
      const eventHandlerFn = (eventParseResult: EventParseResult) => { eventParseResult.err ...}
      const deploySubscription: DeploySubscription = {
        deployHash,
        eventHandlerFn
      };
      watcher.subscribe([deploySubscription]);
```
I believe `EventSubscription` should maybe also be exported for watching events, but I didn't want to speculate.

- And last, modify this line

```js 
 const requestUrl = `${this.eventStreamUrl}?start_from=${eventId}`; 
``` 

to manage `&` or `?` because if you have a backend proxy then  `eventStreamUrl` might look like this

```
http://mybackendurl/api/events/main?api_url=http://X.X.X.X:9999
``` 

you want a tranform to 

```
http://mybackendurl/api/events/main?api_url=http://X.X.X.X:9999&start_from=0
``` 
and not

```
http://mybackendurl/api/events/main?api_url=http://X.X.X.X:9999?start_from=0
```  
which is not a valid url.
      

