### PR TITLE
Added polyfills for webpack

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -20,9 +20,11 @@
         "ethereum-cryptography": "^0.1.3",
         "fetch-h2": "^3.0.2",
         "glob": "^7.1.6",
+        "https-browserify": "^1.0.0",
         "humanize-duration": "^3.24.0",
         "key-encoder": "^2.0.3",
         "reflect-metadata": "^0.1.13",
+        "tls-browserify": "^0.2.2",
         "ts-results": "npm:@casperlabs/ts-results@^3.3.4",
         "tweetnacl-ts": "^1.0.3",
         "tweetnacl-util": "^0.15.0",
@@ -39,6 +41,7 @@
         "@typescript-eslint/eslint-plugin": "^4.16.1",
         "@typescript-eslint/parser": "^4.16.1",
         "assert": "^2.0.0",
+        "browserify-zlib": "^0.2.0",
         "buffer": "^6.0.3",
         "chai": "^4.2.0",
         "concurrently": "^6.0.0",
@@ -1748,6 +1751,15 @@
       "resolved": "https://registry.npmjs.org/bn.js/-/bn.js-5.2.0.tgz",
       "integrity": "sha512-D7iWRBvnZE8ecXiLj/9wbxH7Tk79fAh8IHaTNq1RWRixsS02W+5qS+iE9yq6RYl0asXx5tw0bLhmT5pIfbSquw==",
       "dev": true
+    },
+    "node_modules/browserify-zlib": {
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/browserify-zlib/-/browserify-zlib-0.2.0.tgz",
+      "integrity": "sha512-Z942RysHXmJrhqk88FmKBVq/v5tqmSkDz7p54G/MGyjMnCFFnC79XWNbg+Vta8W6Wb2qtSZTSxIGkJrRpCFEiA==",
+      "dev": true,
+      "dependencies": {
+        "pako": "~1.0.5"
+      }
     },
     "node_modules/browserslist": {
       "version": "4.21.2",
@@ -3730,6 +3742,11 @@
       "integrity": "sha512-H2iMtd0I4Mt5eYiapRdIDjp+XzelXQ0tFE4JS7YFwFevXXMmOp9myNrUvCg0D6ws8iqkRPBfKHgbwig1SmlLfg==",
       "dev": true
     },
+    "node_modules/https-browserify": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/https-browserify/-/https-browserify-1.0.0.tgz",
+      "integrity": "sha512-J+FkSdyD+0mA0N+81tMotaRMfSL9SGi+xpD3T6YApKsc3bGSXJlfXri3VyFOeYkfLRQisDk1W+jIFFKBeUBbBg=="
+    },
     "node_modules/human-signals": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/human-signals/-/human-signals-1.1.1.tgz",
@@ -5233,6 +5250,14 @@
         }
       }
     },
+    "node_modules/node-forge": {
+      "version": "0.7.6",
+      "resolved": "https://registry.npmjs.org/node-forge/-/node-forge-0.7.6.tgz",
+      "integrity": "sha512-sol30LUpz1jQFBjOKwbjxijiE3b6pjd74YwfD0fJOKPjF+fONKb2Yg8rYgS6+bK6VDl+/wfr4IYpC7jDzLUIfw==",
+      "engines": {
+        "node": "*"
+      }
+    },
     "node_modules/node-gyp-build": {
       "version": "4.2.3",
       "resolved": "https://registry.npmjs.org/node-gyp-build/-/node-gyp-build-4.2.3.tgz",
@@ -5726,6 +5751,12 @@
       "engines": {
         "node": ">=8"
       }
+    },
+    "node_modules/pako": {
+      "version": "1.0.11",
+      "resolved": "https://registry.npmjs.org/pako/-/pako-1.0.11.tgz",
+      "integrity": "sha512-4hLB8Py4zZce5s4yd9XzopqwVv/yGNhV1Bl8NTmCq1763HeK2+EwVTv+leGeL13Dnh2wfbqowVPXCIO0z4taYw==",
+      "dev": true
     },
     "node_modules/parent-module": {
       "version": "1.0.1",
@@ -7234,6 +7265,14 @@
       "integrity": "sha512-iOqSav00cVxEEICeD7TjLB1sueEL+81Wpzp2bY17uZjZN0pWZPuo4suZ/61VujxmqSGFfgOcNuTZ85QJwNZQpw==",
       "dependencies": {
         "readable-stream": "3"
+      }
+    },
+    "node_modules/tls-browserify": {
+      "version": "0.2.2",
+      "resolved": "https://registry.npmjs.org/tls-browserify/-/tls-browserify-0.2.2.tgz",
+      "integrity": "sha512-7xLhLW2mg7F/Wy9nDCR+QrdA0O3XstSeWbUckKYpDiIxI07bDhKK6yXVNLObTspeMTaP6x9zitygnXu16sr5hg==",
+      "dependencies": {
+        "node-forge": "^0.7.0"
       }
     },
     "node_modules/to-arraybuffer": {
@@ -9638,6 +9677,15 @@
         }
       }
     },
+    "browserify-zlib": {
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/browserify-zlib/-/browserify-zlib-0.2.0.tgz",
+      "integrity": "sha512-Z942RysHXmJrhqk88FmKBVq/v5tqmSkDz7p54G/MGyjMnCFFnC79XWNbg+Vta8W6Wb2qtSZTSxIGkJrRpCFEiA==",
+      "dev": true,
+      "requires": {
+        "pako": "~1.0.5"
+      }
+    },
     "browserslist": {
       "version": "4.21.2",
       "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.21.2.tgz",
@@ -11147,6 +11195,11 @@
       "integrity": "sha512-H2iMtd0I4Mt5eYiapRdIDjp+XzelXQ0tFE4JS7YFwFevXXMmOp9myNrUvCg0D6ws8iqkRPBfKHgbwig1SmlLfg==",
       "dev": true
     },
+    "https-browserify": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/https-browserify/-/https-browserify-1.0.0.tgz",
+      "integrity": "sha512-J+FkSdyD+0mA0N+81tMotaRMfSL9SGi+xpD3T6YApKsc3bGSXJlfXri3VyFOeYkfLRQisDk1W+jIFFKBeUBbBg=="
+    },
     "human-signals": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/human-signals/-/human-signals-1.1.1.tgz",
@@ -12254,6 +12307,11 @@
         "whatwg-url": "^5.0.0"
       }
     },
+    "node-forge": {
+      "version": "0.7.6",
+      "resolved": "https://registry.npmjs.org/node-forge/-/node-forge-0.7.6.tgz",
+      "integrity": "sha512-sol30LUpz1jQFBjOKwbjxijiE3b6pjd74YwfD0fJOKPjF+fONKb2Yg8rYgS6+bK6VDl+/wfr4IYpC7jDzLUIfw=="
+    },
     "node-gyp-build": {
       "version": "4.2.3",
       "resolved": "https://registry.npmjs.org/node-gyp-build/-/node-gyp-build-4.2.3.tgz",
@@ -12625,6 +12683,12 @@
         "lodash.flattendeep": "^4.4.0",
         "release-zalgo": "^1.0.0"
       }
+    },
+    "pako": {
+      "version": "1.0.11",
+      "resolved": "https://registry.npmjs.org/pako/-/pako-1.0.11.tgz",
+      "integrity": "sha512-4hLB8Py4zZce5s4yd9XzopqwVv/yGNhV1Bl8NTmCq1763HeK2+EwVTv+leGeL13Dnh2wfbqowVPXCIO0z4taYw==",
+      "dev": true
     },
     "parent-module": {
       "version": "1.0.1",
@@ -13772,6 +13836,14 @@
       "integrity": "sha512-iOqSav00cVxEEICeD7TjLB1sueEL+81Wpzp2bY17uZjZN0pWZPuo4suZ/61VujxmqSGFfgOcNuTZ85QJwNZQpw==",
       "requires": {
         "readable-stream": "3"
+      }
+    },
+    "tls-browserify": {
+      "version": "0.2.2",
+      "resolved": "https://registry.npmjs.org/tls-browserify/-/tls-browserify-0.2.2.tgz",
+      "integrity": "sha512-7xLhLW2mg7F/Wy9nDCR+QrdA0O3XstSeWbUckKYpDiIxI07bDhKK6yXVNLObTspeMTaP6x9zitygnXu16sr5hg==",
+      "requires": {
+        "node-forge": "^0.7.0"
       }
     },
     "to-arraybuffer": {

--- a/package.json
+++ b/package.json
@@ -54,6 +54,7 @@
     "@typescript-eslint/eslint-plugin": "^4.16.1",
     "@typescript-eslint/parser": "^4.16.1",
     "assert": "^2.0.0",
+    "browserify-zlib": "^0.2.0",
     "buffer": "^6.0.3",
     "chai": "^4.2.0",
     "concurrently": "^6.0.0",

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -47,7 +47,12 @@ const clientConfig = {
       asert: require.resolve('assert'),
       http: require.resolve('stream-http'),
       url: require.resolve('url/'),
-      fs: false
+      zlib: require.resolve('browserify-zlib'),
+      fs: false,
+      tls: false,
+      https: false,
+      http2: false,
+      net: false
     }
   },
   plugins: [


### PR DESCRIPTION
Because of the new dependencies I needed to add polyfills for some of the native nodejs deps - like `browserify-zlib`.
But polyfilling some of them doesn't make sense or is not possible like `fs` or `net`.