### PR TITLE
CI: add markdown skip workaround

### DIFF
--- a/.github/workflows/markdown-skip.yml
+++ b/.github/workflows/markdown-skip.yml
@@ -1,0 +1,30 @@
+name: markdown-skip
+
+on:
+  push:
+    branches:
+      - "dev"
+      - "feat-*"
+      - "release-*"
+    paths:
+      - '**.md'
+
+  pull_request:
+    branches:
+      - "dev"
+      - "feat-*"
+      - "release-*"
+    paths:
+      - '**.md'
+
+jobs:
+  build:
+    runs-on: ubuntu-20.04
+    strategy:
+      fail-fast: false
+      matrix:
+        # See supported Node.js release schedule at https://nodejs.org/en/about/releases/
+        node-version: [16.x]
+
+    steps:
+      - run: 'echo "Markdown only change, no lints required"'


### PR DESCRIPTION
Changes:
- adds workaround for markdown only type changes

Notes:
https://docs.github.com/en/repositories/configuring-branches-and-merges-in-your-repository/defining-the-mergeability-of-pull-requests/troubleshooting-required-status-checks#handling-skipped-but-required-checks

Ticket: https://app.zenhub.com/workspaces/cn-sre-60d363546afb85000e491ff6/issues/gh/casper-network/sre/710