### PR TITLE
Secp256k1 sign fix

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,12 @@ All notable changes to casper-js-sdk.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/), and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## 2.13.2
+
+### Fixed
+
+- Fix for wrong signatures being generated for SECP256K1 keys - it was missing `der: false` setting in a function call
+
 ## 2.13.1
 
 ### Added

--- a/e2e/lib/Keys.test.ts
+++ b/e2e/lib/Keys.test.ts
@@ -103,21 +103,8 @@ describe('Ed25519', () => {
 });
 
 describe('Secp256K1', () => {
-  it('calculates the account hash', async () => {
-    const signKeyPair = await Secp256K1.new();
-    // use lower case for node-rs
-    const name = Buffer.from('secp256k1'.toLowerCase());
-    const sep = decodeBase16('00');
-    const bytes = Buffer.concat([name, sep, signKeyPair.publicKey.value()]);
-    const hash = byteHash(bytes);
-
-    expect(Secp256K1.accountHash(signKeyPair.publicKey.value())).deep.equal(
-      hash
-    );
-  });
-
-  it('should generate PEM file for Secp256K1 correctly', async () => {
-    const signKeyPair = await Secp256K1.new();
+  it('should generate PEM file for Secp256K1 correctly', () => {
+    const signKeyPair = Secp256K1.new();
 
     // export key in pem to save
     const publicKeyInPem = signKeyPair.exportPublicKeyInPem();
@@ -154,11 +141,5 @@ describe('Secp256K1', () => {
     expect(ecdh.getPublicKey('hex', 'compressed')).to.deep.equal(
       encodeBase16(signKeyPair.publicKey.value())
     );
-
-    // expect we could sign the message and verify the signature later.
-    const message = Buffer.from('hello world');
-    const signature = signKeyPair.sign(Buffer.from(message));
-    // expect we could verify the signature created by ourself
-    expect(signKeyPair.verify(signature, message)).to.equal(true);
   });
 });

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "casper-js-sdk",
-  "version": "2.13.1",
+  "version": "2.13.2",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "casper-js-sdk",
-      "version": "2.13.1",
+      "version": "2.13.2",
       "license": "Apache 2.0",
       "dependencies": {
         "@ethersproject/bignumber": "^5.0.8",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "casper-js-sdk",
-  "version": "2.13.1",
+  "version": "2.13.2",
   "license": "Apache 2.0",
   "description": "SDK to interact with the Casper blockchain",
   "homepage": "https://github.com/casper-ecosystem/casper-js-sdk#README.md",

--- a/src/lib/Keys.test.ts
+++ b/src/lib/Keys.test.ts
@@ -1,8 +1,8 @@
 import { expect } from 'chai';
 
-import { byteHash } from './ByteConverters';
 import { decodeBase16, decodeBase64 } from './Conversions';
 import { Ed25519, Secp256K1 } from './Keys';
+import { byteHash } from './ByteConverters';
 
 describe('Ed25519', () => {
   it('calculates the account hash', () => {

--- a/src/lib/Keys.test.ts
+++ b/src/lib/Keys.test.ts
@@ -1,7 +1,8 @@
 import { expect } from 'chai';
+
+import { byteHash } from './ByteConverters';
 import { decodeBase16, decodeBase64 } from './Conversions';
 import { Ed25519, Secp256K1 } from './Keys';
-import { byteHash } from './ByteConverters';
 
 describe('Ed25519', () => {
   it('calculates the account hash', () => {
@@ -35,8 +36,8 @@ describe('Ed25519', () => {
 });
 
 describe('Secp256K1', () => {
-  it('calculates the account hash', async () => {
-    const signKeyPair = await Secp256K1.new();
+  it('calculates the account hash', () => {
+    const signKeyPair = Secp256K1.new();
     // use lower case for node-rs
     const name = Buffer.from('secp256k1'.toLowerCase());
     const sep = decodeBase16('00');
@@ -46,5 +47,23 @@ describe('Secp256K1', () => {
     expect(Secp256K1.accountHash(signKeyPair.publicKey.value())).deep.equal(
       hash
     );
+  });
+
+  it('should generate r+s signature', () => {
+    const signKeyPair = Secp256K1.new();
+    const message = Uint8Array.from(Buffer.from('Hello Secp256K1'));
+
+    const signature = signKeyPair.sign(message);
+
+    expect(signature.length).to.equal(64);
+  });
+
+  it('should sign and verify message', () => {
+    const signKeyPair = Secp256K1.new();
+    const message = Uint8Array.from(Buffer.from('Hello Secp256K1'));
+
+    const signature = signKeyPair.sign(message);
+
+    expect(signKeyPair.verify(signature, message)).to.equal(true);
   });
 });

--- a/src/lib/Keys.ts
+++ b/src/lib/Keys.ts
@@ -12,9 +12,9 @@ import { sha512 } from '@noble/hashes/sha512';
 import { hmac } from '@noble/hashes/hmac';
 import KeyEncoder from 'key-encoder';
 
-import { decodeBase64, encodeBase16, encodeBase64 } from '../index';
-import { CLPublicKey } from './CLValue';
 import { byteHash } from './ByteConverters';
+import { CLPublicKey } from './CLValue';
+import { decodeBase64, encodeBase16, encodeBase64 } from './Conversions';
 import { SignatureAlgorithm } from './types';
 
 export { SignatureAlgorithm } from './types';
@@ -635,7 +635,10 @@ export class Secp256K1 extends AsymmetricKey {
   public sign(msg: Uint8Array): Uint8Array {
     const signature = secp256k1.signSync(
       sha256(Buffer.from(msg)),
-      this.privateKey
+      this.privateKey,
+      {
+        der: false
+      }
     );
     return signature;
   }

--- a/src/lib/Keys.ts
+++ b/src/lib/Keys.ts
@@ -12,9 +12,9 @@ import { sha512 } from '@noble/hashes/sha512';
 import { hmac } from '@noble/hashes/hmac';
 import KeyEncoder from 'key-encoder';
 
-import { byteHash } from './ByteConverters';
+import { decodeBase64, encodeBase16, encodeBase64 } from '../index';
 import { CLPublicKey } from './CLValue';
-import { decodeBase64, encodeBase16, encodeBase64 } from './Conversions';
+import { byteHash } from './ByteConverters';
 import { SignatureAlgorithm } from './types';
 
 export { SignatureAlgorithm } from './types';


### PR DESCRIPTION
## 2.13.2

### Fixed

- Fix for wrong signatures being generated for SECP256K1 keys - it was missing `der: false` setting in a function call