### PR TITLE
Fix get state root hash RPC

### DIFF
--- a/src/services/CasperServiceByJsonRPC.ts
+++ b/src/services/CasperServiceByJsonRPC.ts
@@ -424,7 +424,7 @@ export class CasperServiceByJsonRPC {
       .request(
         {
           method: 'chain_get_state_root_hash',
-          params: blockHashBase16 ? { block_identifier: blockHashBase16 } : []
+          params: blockHashBase16 ? [{ Hash: blockHashBase16 }] : []
         },
         props?.timeout
       )


### PR DESCRIPTION
State root hash RPC signature have changed with 1.5 https://docs.casper.network/developers/json-rpc/json-rpc-informational/#chain-get-state-root-hash

So the current implementation doesn't work with testnet 1.5.