### PR TITLE
chore: add `@noble/curves` dependency

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,17 +1,18 @@
 {
   "name": "casper-js-sdk",
-  "version": "2.14.0",
+  "version": "2.15.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "casper-js-sdk",
-      "version": "2.14.0",
+      "version": "2.15.0",
       "license": "Apache 2.0",
       "dependencies": {
         "@ethersproject/bignumber": "^5.0.8",
         "@ethersproject/bytes": "^5.0.5",
         "@ethersproject/constants": "^5.0.5",
+        "@noble/curves": "^1.1.0",
         "@noble/ed25519": "^1.7.3",
         "@noble/hashes": "^1.2.0",
         "@noble/secp256k1": "^1.7.1",
@@ -777,17 +778,14 @@
       }
     },
     "node_modules/@noble/curves": {
-      "version": "0.8.3",
-      "resolved": "https://registry.npmjs.org/@noble/curves/-/curves-0.8.3.tgz",
-      "integrity": "sha512-OqaOf4RWDaCRuBKJLDURrgVxjLmneGsiCXGuzYB5y95YithZMA6w4uk34DHSm0rKMrrYiaeZj48/81EvaAScLQ==",
-      "funding": [
-        {
-          "type": "individual",
-          "url": "https://paulmillr.com/funding/"
-        }
-      ],
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@noble/curves/-/curves-1.1.0.tgz",
+      "integrity": "sha512-091oBExgENk/kGj3AZmtBDMpxQPDtxQABR2B9lb1JbVTs6ytdzZNwvhxQ4MWasRNEzlbEH8jCWFCwhF/Obj5AA==",
       "dependencies": {
-        "@noble/hashes": "1.3.0"
+        "@noble/hashes": "1.3.1"
+      },
+      "funding": {
+        "url": "https://paulmillr.com/funding/"
       }
     },
     "node_modules/@noble/ed25519": {
@@ -802,15 +800,15 @@
       ]
     },
     "node_modules/@noble/hashes": {
-      "version": "1.3.0",
-      "resolved": "https://registry.npmjs.org/@noble/hashes/-/hashes-1.3.0.tgz",
-      "integrity": "sha512-ilHEACi9DwqJB0pw7kv+Apvh50jiiSyR/cQ3y4W7lOR5mhvn/50FLUfsnfJz0BDZtl/RR16kXvptiv6q1msYZg==",
-      "funding": [
-        {
-          "type": "individual",
-          "url": "https://paulmillr.com/funding/"
-        }
-      ]
+      "version": "1.3.1",
+      "resolved": "https://registry.npmjs.org/@noble/hashes/-/hashes-1.3.1.tgz",
+      "integrity": "sha512-EbqwksQwz9xDRGfDST86whPBgM65E0OH/pCgqW0GBVzO22bNE+NuIbeTb714+IfSjU3aRk47EUvXIb5bTsenKA==",
+      "engines": {
+        "node": ">= 16"
+      },
+      "funding": {
+        "url": "https://paulmillr.com/funding/"
+      }
     },
     "node_modules/@noble/secp256k1": {
       "version": "1.7.1",
@@ -1151,6 +1149,31 @@
         "@noble/hashes": "~1.3.0",
         "@scure/base": "~1.1.0"
       }
+    },
+    "node_modules/@scure/bip32/node_modules/@noble/curves": {
+      "version": "0.8.3",
+      "resolved": "https://registry.npmjs.org/@noble/curves/-/curves-0.8.3.tgz",
+      "integrity": "sha512-OqaOf4RWDaCRuBKJLDURrgVxjLmneGsiCXGuzYB5y95YithZMA6w4uk34DHSm0rKMrrYiaeZj48/81EvaAScLQ==",
+      "funding": [
+        {
+          "type": "individual",
+          "url": "https://paulmillr.com/funding/"
+        }
+      ],
+      "dependencies": {
+        "@noble/hashes": "1.3.0"
+      }
+    },
+    "node_modules/@scure/bip32/node_modules/@noble/hashes": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/@noble/hashes/-/hashes-1.3.0.tgz",
+      "integrity": "sha512-ilHEACi9DwqJB0pw7kv+Apvh50jiiSyR/cQ3y4W7lOR5mhvn/50FLUfsnfJz0BDZtl/RR16kXvptiv6q1msYZg==",
+      "funding": [
+        {
+          "type": "individual",
+          "url": "https://paulmillr.com/funding/"
+        }
+      ]
     },
     "node_modules/@scure/bip39": {
       "version": "1.2.0",

--- a/package.json
+++ b/package.json
@@ -111,6 +111,7 @@
     "@ethersproject/bignumber": "^5.0.8",
     "@ethersproject/bytes": "^5.0.5",
     "@ethersproject/constants": "^5.0.5",
+    "@noble/curves": "^1.1.0",
     "@noble/ed25519": "^1.7.3",
     "@noble/hashes": "^1.2.0",
     "@noble/secp256k1": "^1.7.1",


### PR DESCRIPTION
## Changes
* include `@noble/curves` dependency in package.json


## Reason

The `@noble/curves` package being imported directly [here](https://github.com/casper-ecosystem/casper-js-sdk/blob/ddf53131ba247d125bcce0cb044bbb8ef84f9615/src/lib/CasperHDKeys/hdkey.ts#L4) and isn't the part of dependencies in package.json. It's a problem when using pnpm + webpack for electron. Came up during ledger-live integration. 

Would it be possible to include this change and make a minor release thereafter? 