### PR TITLE
Fix "socket hang up" / ECONNRESET on consecutive requests with Node.js 19 and Node.js 20

### DIFF
--- a/package.json
+++ b/package.json
@@ -58,7 +58,7 @@
     "@types/lodash": "^4.14.191",
     "@types/mocha": "^5.2.7",
     "@types/node": "^14.14.31",
-    "@types/node-fetch": "^2.6.4",
+    "@types/node-fetch": "^2.6.13",
     "@types/sinon": "^10.0.13",
     "@typescript-eslint/eslint-plugin": "^5.52.0",
     "@typescript-eslint/parser": "^5.52.0",

--- a/package.json
+++ b/package.json
@@ -58,7 +58,7 @@
     "@types/lodash": "^4.14.191",
     "@types/mocha": "^5.2.7",
     "@types/node": "^14.14.31",
-    "@types/node-fetch": "^2.6.13",
+    "@types/node-fetch": "^2.6.4",
     "@types/sinon": "^10.0.13",
     "@typescript-eslint/eslint-plugin": "^5.52.0",
     "@typescript-eslint/parser": "^5.52.0",
@@ -123,7 +123,7 @@
     "humanize-duration": "^3.24.0",
     "key-encoder": "^2.0.3",
     "lodash": "^4.17.21",
-    "node-fetch": "^2.6.11",
+    "node-fetch": "2.6.13",
     "reflect-metadata": "^0.1.13",
     "ts-results": "npm:@casperlabs/ts-results@^3.3.4",
     "typedjson": "^1.6.0-rc2"


### PR DESCRIPTION
## Changes ##

`node-fetch` version updated to ^2.6.13

## Reason ##

The reason is [the bug](https://github.com/node-fetch/node-fetch/issues/1735) when we cant send more than 1 request using Casper JS SDK.