### PR TITLE
fix: rename lib.js to lib.web.js

### DIFF
--- a/.github/workflows/publish-casper-client-sdk.yml
+++ b/.github/workflows/publish-casper-client-sdk.yml
@@ -32,7 +32,7 @@ jobs:
     - name: Get latest release version number
       id: get_version
       uses: battila7/get-version-action@d97fbc34ceb64d1f5d95f4dfd6dce33521ccccf5 #v2.3.0
-    - run: cp dist/lib.js casper-js-sdk.v${{ steps.get_version.outputs.version }}.js
+    - run: cp dist/lib.web.js casper-js-sdk.v${{ steps.get_version.outputs.version }}.js
     - uses: meeDamian/github-release@7ae19492500104f636b3fee4d8103af0fed36c8e #v2.0.3
       with:
         token: ${{ secrets.GITHUB_TOKEN }}

--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
     "url": "https://github.com/casper-ecosystem/casper-js-sdk.git"
   },
   "main": "dist/lib.node.js",
-  "browser": "dist/lib.js",
+  "browser": "dist/lib.web.js",
   "types": "dist/index.d.ts",
   "scripts": {
     "prepare": "husky-run install",

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -70,7 +70,7 @@ const clientConfig = {
   ],
   output: {
     path: path.resolve(__dirname, 'dist'),
-    filename: 'lib.js',
+    filename: 'lib.web.js',
     libraryTarget: 'umd'
   }
 };


### PR DESCRIPTION
This fixes TypeScript support for NodeNext/Node16/Bundler moduleResolution.

The issue was that the `./dist/lib.js` has a higher precedence than `./dist/lib/index.d.ts` when TypeScript tries to resolve `"./lib"` imports/exports.

Instead of renaming the whole `lib/` folder I decided to add a infix to the `lib.js` artifact. But to solve the issue you could've renamed the directory instead.

Resolves #386