### PR TITLE
Prevent testnet version tests from blocking

### DIFF
--- a/.github/workflows/ci-casper-client-sdk.yml
+++ b/.github/workflows/ci-casper-client-sdk.yml
@@ -78,21 +78,9 @@ jobs:
       # test testnet
       - name: Get the testnet version
         id: get-testnet-version
+        continue-on-error: true
         run: echo "TESTNET_VERSION=$(curl -s -X POST --data-raw '${{ env.VERSION_QUERY }}' -H "Content-Type:application/json" ${{ env.TESTNET_NODE_URL }} | jq -r .result.build_version | cut -d "-" -f 1)" >> "$GITHUB_ENV"
 
       - name: Test RPC - testnet ${{ env.TESTNET_VERSION }}
+        continue-on-error: true
         run: npx casper-node-launcher-js node v${{ env.TESTNET_VERSION }} --daemon && npm run test:e2e && npx casper-node-launcher-js stop
-
-      - name: Get Latest Casper-Node Tag Version
-        run: |
-          echo "CASPER_TAG_VERSION=$(curl -s ${{ env.GH_API_URL }} | jq -r '.[].name' | grep 'v*' | sort -V | sed 's/_$//' | tail -n1)" >> $GITHUB_ENV
-        env:
-          GH_API_URL: 'https://api.github.com/repos/casper-network/casper-node/tags'
-
-      - name: Test RPC - Casper Node - ${{ env.CASPER_TAG_VERSION }}
-        # Runs action if the latest version is different from mainnet and testnet
-        if: ${{ env.CASPER_TAG_VERSION }} != v${{ env.MAINNET_VERSION }} && ${{ env.CASPER_TAG_VERSION }} != v${{ env.TESTNET_VERSION }}
-        run: npx casper-node-launcher-js node ${{ env.CASPER_TAG_VERSION }} --daemon && npm run test:e2e && npx casper-node-launcher-js stop
-
-      - name: Test RPC - Casper Node - DEV
-        run: npx casper-node-launcher-js node dev --daemon && npm run test:e2e && npx casper-node-launcher-js stop

--- a/.github/workflows/nightly-scheduled-test.yml
+++ b/.github/workflows/nightly-scheduled-test.yml
@@ -58,9 +58,11 @@ jobs:
         run: echo "TESTNET_VERSION=$(curl -s -X POST --data-raw '${{ env.VERSION_QUERY }}' -H "Content-Type:application/json" ${{ env.TESTNET_NODE_URL }} | jq -r .result.build_version | cut -d "-" -f 1)" >> "$GITHUB_ENV"
 
       - name: Test RPC - testnet ${{ env.TESTNET_VERSION }}
+        continue-on-error: true
         run: npx casper-node-launcher-js node v${{ env.TESTNET_VERSION }} --daemon && npm run test:e2e && npx casper-node-launcher-js stop
 
       - name: Test RPC - CN Dev
+        continue-on-error: true
         run: npx casper-node-launcher-js node dev --daemon && npm run test:e2e && npx casper-node-launcher-js stop
 
       - name: Get Latest Casper-Node Tag Version
@@ -79,6 +81,7 @@ jobs:
           GH_API_URL: 'https://api.github.com/repos/casper-network/casper-node/branches'
 
       - name: Test RPC - CN RC - ${{ env.CASPER_RC_VERSION }}
+        continue-on-error: true
         run: npx casper-node-launcher-js node ${{env.CASPER_TAG_VERSION }} --daemon && npm run test:e2e && npx casper-node-launcher-js stop
 
       - name: Slack Notification


### PR DESCRIPTION
This should prevent blocking the tests flow because of the testnet releases. 

There is possibility that testnet is running different version then the latest tagged release in `casper-node` repo. This should not cause the whole test suit to fail as its happening now. 

As SDK should be compatible with the current version of the `mainnet` - I would make all the `testnet` related tests optional. Hope this description is clear 😓 .