### PR TITLE
Unified naming convention

### DIFF
--- a/src/lib/CLValue/Abstract.ts
+++ b/src/lib/CLValue/Abstract.ts
@@ -62,6 +62,14 @@ export abstract class CLValue {
   }
 }
 
+export abstract class CLKeyVariant {
+  abstract toFormattedStr(): string;
+
+  static fromStr(hexStr: string): CLKeyVariant {
+    throw Error(`Unknown string provided: ${hexStr}`);
+  }
+}
+
 export class CLValueParsers {
   static fromJSON(json: any): Result<CLValue, string> {
     const clType = matchTypeToCLType(json.cl_type);

--- a/src/lib/CLValue/AccountHash.test.ts
+++ b/src/lib/CLValue/AccountHash.test.ts
@@ -23,4 +23,15 @@ describe('CLAccountHash', () => {
     expect(bytes).to.deep.eq(expectedBytes);
     expect(hash).to.deep.eq(expectedHash);
   });
+
+  it('Dealing with formatted strings', () => {
+    const hashStr = 'account-hash-9fb3803b335f14b083b97400e57d5c8e8ad0ec5859a51225b6611e34357c8d77';
+
+    const fromStr = CLAccountHash.fromFormattedStr(hashStr);
+
+    expect(fromStr.toFormattedStr()).to.eq(fromStr);
+
+    const badFn = () => CLAccountHash.fromFormattedStr('9fb3803b335f14b083b97400e57d5c8e8ad0ec5859a51225b6611e34357c8d77');
+    expect(badFn).to.throw();
+  });
 });

--- a/src/lib/CLValue/AccountHash.ts
+++ b/src/lib/CLValue/AccountHash.ts
@@ -63,7 +63,7 @@ export class CLAccountHash extends CLValue {
     return this.data;
   }
 
-  toHashStr(): string {
+  toFormattedStr(): string {
     const bytes = this.data;
     const hashHex = Buffer.from(bytes).toString('hex');
     return `account-hash-${hashHex}`;

--- a/src/lib/CLValue/AccountHash.ts
+++ b/src/lib/CLValue/AccountHash.ts
@@ -4,6 +4,7 @@ import {
   CLValue,
   CLValueBytesParsers,
   CLType,
+  CLKeyVariant,
   CLErrorCodes,
   ResultAndRemainder,
   ToBytesResult,
@@ -42,8 +43,10 @@ export class CLAccountHashBytesParser extends CLValueBytesParsers {
   }
 }
 
+const ACCOUNT_HASH_PREFIX = 'account-hash';
+
 /** A cryptographic public key. */
-export class CLAccountHash extends CLValue {
+export class CLAccountHash extends CLValue implements CLKeyVariant {
   data: Uint8Array;
   /**
    * Constructs a new `AccountHash`.
@@ -66,6 +69,17 @@ export class CLAccountHash extends CLValue {
   toFormattedStr(): string {
     const bytes = this.data;
     const hashHex = Buffer.from(bytes).toString('hex');
-    return `account-hash-${hashHex}`;
+    return `${ACCOUNT_HASH_PREFIX}-${hashHex}`;
+  }
+
+  static fromFormattedStr(hexStr: string): CLAccountHash {
+    if (hexStr.startsWith(`${ACCOUNT_HASH_PREFIX}-`)) {
+      const formatedString = hexStr.replace(`${ACCOUNT_HASH_PREFIX}-`, '');
+      const bytes = Uint8Array.from(Buffer.from(formatedString, 'hex'));
+      return new CLAccountHash(bytes);
+    }
+    throw new Error(
+      `Invalid string format. It needs to start with ${ACCOUNT_HASH_PREFIX}`
+    );
   }
 }

--- a/src/services/CasperServiceByJsonRPC.ts
+++ b/src/services/CasperServiceByJsonRPC.ts
@@ -375,7 +375,7 @@ export class CasperServiceByJsonRPC {
     if (accountIdentifier instanceof CLPublicKey) {
       identifier = accountIdentifier.toHex();
     } else if (accountIdentifier instanceof CLAccountHash) {
-      identifier = accountIdentifier.toHashStr();
+      identifier = accountIdentifier.toFormattedStr();
     }
     const params: any = {
       account_identifier: identifier


### PR DESCRIPTION
as `CLAccountHash` is one of the `KeyVariants` added a convention that all `KeyVariants` will follow