### PR TITLE
Making it possible to specify contract by hash and name.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,22 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
   ### Removed
  -->
 
+## [3.0.0-rc04] - 2024-07-25
+
+### Added
+
+- Brought back the functionality of setting contract hash (`setContractHash` method) in `Contract` class. Previously even using that method would ignore the contract hash due to a bug in the node. Now setting it will imply that the contract endpoints need to by called by contract hash. You still can use `setContractName`, but `setContractHash` takes priority if both are used.
+- Added the possibility to muffle deprecation warnings in `CasperServiceByJsonRPC`. You can now pass `muffleDeprecationWarnings` as an optional parameter to the constructor. If set to `true`, the SDK will not log any deprecation warnings from that class. Defaults to `false`
+
+### Removed
+
+- `TransactionSessionKind` since field kind was removed from `Session` implementation of `TransactionTarget`
+- Removed usages of `toHex`, `fromHex` and `toAccountHashStr` since they are deprecated.
+
+### Changed
+
+- `waitForDeploy` and `waitForTransaction` methods will fail fast if the results for getting deploy/transaction info is present but was not successfull.
+
 ## [3.0.0-rc02] - 2024-07-05
 
 This release candidate is compatible with [#node RC3](https://github.com/casper-network/casper-node/tree/release-2.0.0-rc2)

--- a/e2e/services/CasperServiceByJsonRPC.test.ts
+++ b/e2e/services/CasperServiceByJsonRPC.test.ts
@@ -38,12 +38,7 @@ import {
   TransactionCategoryMint,
   makeV1Transaction
 } from '../../src/lib/TransactionUtil';
-import {
-  Native,
-  Session,
-  Stored,
-  TransactionSessionKind
-} from '../../src/lib/TransactionTarget';
+import { Native, Session, Stored } from '../../src/lib/TransactionTarget';
 import { Call, Custom, Transfer } from '../../src/lib/TransactionEntryPoint';
 import { Standard } from '../../src/lib/TransactionScheduling';
 import { InitiatorAddr } from '../../src/lib/InitiatorAddr';
@@ -460,7 +455,6 @@ describe('CasperServiceByJsonRPC', () => {
     assert.exists(contractHash);
 
     cep18.setContractHash(contractHash!);
-    cep18.setContractName(`cep18_contract_hash_${tokenName}`);
     const fetchedTokenName = await cep18.queryContractData(['name']);
     const fetchedTokenSymbol = await cep18.queryContractData(['symbol']);
     const fetchedTokenDecimals: BigNumber = await cep18.queryContractData([
@@ -512,7 +506,7 @@ describe('CasperServiceByJsonRPC', () => {
     result = await client.waitForDeploy(transferDeploy, 100000);
 
     assert.equal(result.deploy.hash, deploy_hash);
-    expect(result.deploy.session).to.have.property('StoredContractByName');
+    expect(result.deploy.session).to.have.property('StoredContractByHash');
     expect(result.execution_info!.execution_result!).to.have.property(
       'Version2'
     );
@@ -526,7 +520,7 @@ describe('CasperServiceByJsonRPC', () => {
   });
 
   //This needs to wait for a fix in the node which currently prevents wasm transactions
-  xit('CEP18 should work deployed via "account_put_transaction"', async () => {
+  it('CEP18 should work deployed via "account_put_transaction"', async () => {
     const casperClient = new CasperClient(NODE_URL);
     const cep18 = new Contract(casperClient);
     const wasmPath = path.resolve(__dirname, './cep18.wasm');
@@ -556,18 +550,13 @@ describe('CasperServiceByJsonRPC', () => {
     const transaction = makeV1Transaction(
       params,
       runtimeArgs,
-      Session.build(
-        TransactionSessionKind.Installer,
-        wasm,
-        TransactionRuntime.VmCasperV1
-      ),
+      Session.build(wasm, TransactionRuntime.VmCasperV1),
       new Call(),
       new Standard(),
       TransactionCategoryInstallUpgrade
     );
     const signedTransaction = transaction.sign([faucetKey]);
     await client.transaction(signedTransaction);
-
     await sleep(2500);
 
     const result = await client.waitForTransaction(signedTransaction, 100000);
@@ -585,7 +574,6 @@ describe('CasperServiceByJsonRPC', () => {
     assert.exists(contractHash);
 
     cep18.setContractHash(contractHash!);
-    cep18.setContractName(`cep18_contract_hash_${tokenName}`);
     const fetchedTokenName = await cep18.queryContractData(['name']);
     const fetchedTokenSymbol = await cep18.queryContractData(['symbol']);
     const fetchedTokenDecimals: BigNumber = await cep18.queryContractData([

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "casper-js-sdk",
-  "version": "3.0.0-rc03",
+  "version": "3.0.0-rc04",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "casper-js-sdk",
-      "version": "3.0.0-rc03",
+      "version": "3.0.0-rc04",
       "license": "Apache 2.0",
       "dependencies": {
         "@ethersproject/bignumber": "^5.7.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,7 @@
       "version": "3.0.0-rc03",
       "license": "Apache 2.0",
       "dependencies": {
-        "@ethersproject/bignumber": "^5.0.8",
+        "@ethersproject/bignumber": "^5.7.0",
         "@ethersproject/bytes": "^5.0.5",
         "@ethersproject/constants": "^5.0.5",
         "@noble/curves": "^1.1.0",
@@ -571,9 +571,9 @@
       }
     },
     "node_modules/@ethersproject/bignumber": {
-      "version": "5.1.1",
-      "resolved": "https://registry.npmjs.org/@ethersproject/bignumber/-/bignumber-5.1.1.tgz",
-      "integrity": "sha512-AVz5iqz7+70RIqoQTznsdJ6DOVBYciNlvO+AlQmPTB6ofCvoihI9bQdr6wljsX+d5W7Yc4nyvQvP4JMzg0Agig==",
+      "version": "5.7.0",
+      "resolved": "https://registry.npmjs.org/@ethersproject/bignumber/-/bignumber-5.7.0.tgz",
+      "integrity": "sha512-n1CAdIHRWjSucQO3MC1zPSVgV/6dy/fjL9pMrPP9peL+QxEg9wOsVqwD4+818B6LUEtaXzVHQiuivzRoxPxUGw==",
       "funding": [
         {
           "type": "individual",
@@ -585,15 +585,20 @@
         }
       ],
       "dependencies": {
-        "@ethersproject/bytes": "^5.1.0",
-        "@ethersproject/logger": "^5.1.0",
-        "bn.js": "^4.4.0"
+        "@ethersproject/bytes": "^5.7.0",
+        "@ethersproject/logger": "^5.7.0",
+        "bn.js": "^5.2.1"
       }
     },
+    "node_modules/@ethersproject/bignumber/node_modules/bn.js": {
+      "version": "5.2.1",
+      "resolved": "https://registry.npmjs.org/bn.js/-/bn.js-5.2.1.tgz",
+      "integrity": "sha512-eXRvHzWyYPBuB4NBy0cmYQjGitUrtqwbvlzP3G6VFnNRbsZQIxQ10PbKKHt8gZ/HW/D/747aDl+QkDqg3KQLMQ=="
+    },
     "node_modules/@ethersproject/bytes": {
-      "version": "5.1.0",
-      "resolved": "https://registry.npmjs.org/@ethersproject/bytes/-/bytes-5.1.0.tgz",
-      "integrity": "sha512-sGTxb+LVjFxJcJeUswAIK6ncgOrh3D8c192iEJd7mLr95V6du119rRfYT/b87WPkZ5I3gRBUYIYXtdgCWACe8g==",
+      "version": "5.7.0",
+      "resolved": "https://registry.npmjs.org/@ethersproject/bytes/-/bytes-5.7.0.tgz",
+      "integrity": "sha512-nsbxwgFXWh9NyYWo+U8atvmMsSdKJprTcICAkvbBffT75qDocbuggBU0SJiVK2MuTrp0q+xvLkTnGMPK1+uA9A==",
       "funding": [
         {
           "type": "individual",
@@ -605,7 +610,7 @@
         }
       ],
       "dependencies": {
-        "@ethersproject/logger": "^5.1.0"
+        "@ethersproject/logger": "^5.7.0"
       }
     },
     "node_modules/@ethersproject/constants": {
@@ -627,9 +632,9 @@
       }
     },
     "node_modules/@ethersproject/logger": {
-      "version": "5.1.0",
-      "resolved": "https://registry.npmjs.org/@ethersproject/logger/-/logger-5.1.0.tgz",
-      "integrity": "sha512-wtUaD1lBX10HBXjjKV9VHCBnTdUaKQnQ2XSET1ezglqLdPdllNOIlLfhyCRqXm5xwcjExVI5ETokOYfjPtaAlw==",
+      "version": "5.7.0",
+      "resolved": "https://registry.npmjs.org/@ethersproject/logger/-/logger-5.7.0.tgz",
+      "integrity": "sha512-0odtFdXu/XHtjQXJYA3u9G0G8btm0ND5Cu8M7i5vhEcE8/HmF4Lbdqanwyv4uQTr2tx6b7fQRmgLrsnpQlmnig==",
       "funding": [
         {
           "type": "individual",

--- a/package.json
+++ b/package.json
@@ -109,7 +109,7 @@
     "webpack-node-externals": "^2.5.2"
   },
   "dependencies": {
-    "@ethersproject/bignumber": "^5.0.8",
+    "@ethersproject/bignumber": "^5.7.0",
     "@ethersproject/bytes": "^5.0.5",
     "@ethersproject/constants": "^5.0.5",
     "@noble/curves": "^1.1.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "casper-js-sdk",
-  "version": "3.0.0-rc03",
+  "version": "3.0.0-rc04",
   "license": "Apache 2.0",
   "description": "SDK to interact with the Casper blockchain",
   "homepage": "https://github.com/casper-ecosystem/casper-js-sdk#README.md",

--- a/run_e2e_locally.sh
+++ b/run_e2e_locally.sh
@@ -1,4 +1,4 @@
-export FAUCET_PRIV_KEY="MC4CAQAwBQYDK2VwBCIEIHXch+pMtOX6MqKQHT+yLnflYxl5XytTYZtYuItlko4g"
+export FAUCET_PRIV_KEY=`cat /home/casperlabs-dev/DEV/src/casper-nctl/assets/net-1/users/user-1/secret_key.pem  | sed -n '2 p'`
 export NODE_URL="http://127.0.0.1:7777/rpc"
 export HTTP_EVENT_STREAM_URL="http://127.0.0.1:19999/events"
 export HTTPS_EVENT_STREAM_URL="https://events.mainnet.casperlabs.io/events"

--- a/src/lib/ByteConverters.test.ts
+++ b/src/lib/ByteConverters.test.ts
@@ -579,13 +579,13 @@ describe(`numbers' toBytes`, () => {
   it('should compute hex from PublicKey correctly', () => {
     const ed25519Account = Keys.Ed25519.new();
     const ed25519AccountHex = ed25519Account.accountHex();
-    expect(CLPublicKey.fromHex(ed25519AccountHex)).to.deep.equal(
+    expect(CLPublicKey.fromFormattedString(ed25519AccountHex)).to.deep.equal(
       ed25519Account.publicKey
     );
 
     const secp256K1Account = Keys.Secp256K1.new();
     const secp256K1AccountHex = secp256K1Account.accountHex();
-    expect(CLPublicKey.fromHex(secp256K1AccountHex)).to.deep.equal(
+    expect(CLPublicKey.fromFormattedString(secp256K1AccountHex)).to.deep.equal(
       secp256K1Account.publicKey
     );
   });

--- a/src/lib/CLValue/PublicKey.test.ts
+++ b/src/lib/CLValue/PublicKey.test.ts
@@ -55,23 +55,23 @@ describe('CLPublicKey', () => {
     const ed25519Account = Keys.Ed25519.new();
     const ed25519AccountHex = ed25519Account.accountHex();
 
-    expect(CLPublicKey.fromHex(ed25519AccountHex).value()).to.deep.equal(
-      ed25519Account.publicKey.value()
-    );
+    expect(
+      CLPublicKey.fromFormattedString(ed25519AccountHex).value()
+    ).to.deep.equal(ed25519Account.publicKey.value());
 
     const secp256K1Account = Keys.Secp256K1.new();
     const secp256K1AccountHex = secp256K1Account.accountHex();
 
-    expect(CLPublicKey.fromHex(secp256K1AccountHex).value()).to.deep.equal(
-      secp256K1Account.publicKey.value()
-    );
+    expect(
+      CLPublicKey.fromFormattedString(secp256K1AccountHex).value()
+    ).to.deep.equal(secp256K1Account.publicKey.value());
 
-    const badFn = () => CLPublicKey.fromHex('1');
+    const badFn = () => CLPublicKey.fromFormattedString('1');
     expect(badFn).to.throw('Asymmetric key error: too short');
 
     // Check mixed case pubkeys
     const goodFn = () =>
-      CLPublicKey.fromHex(
+      CLPublicKey.fromFormattedString(
         '02025853315DB0e4757cC616bfA97800e2FEa61b7cE37D4376D1719148cd0EA5Fc1C'
       );
 
@@ -92,12 +92,12 @@ describe('CLPublicKey', () => {
     const accountKey =
       '019E130bF86201a701cB0DAb4Aae1D6E558781d6fB6195Fc291685777A36cdb388';
 
-    const publicKey = CLPublicKey.fromHex(accountKey);
-    const accountHex = publicKey.toHex(false);
+    const publicKey = CLPublicKey.fromFormattedString(accountKey);
+    const accountHex = publicKey.toFormattedString(false);
 
     expect(accountHex).to.be.eq(accountKey.toLowerCase());
 
-    const checksummedAccountHex = publicKey.toHex(true);
+    const checksummedAccountHex = publicKey.toFormattedString(true);
 
     expect(checksummedAccountHex).to.be.eq(accountKey);
 
@@ -108,7 +108,7 @@ describe('CLPublicKey', () => {
     const accountKey =
       '01f9235ff9c46c990e1e2eee0d531e488101fab48c05b75b8ea9983658e228f06b';
 
-    const publicKey = CLPublicKey.fromHex(accountKey, false);
+    const publicKey = CLPublicKey.fromFormattedString(accountKey, false);
     const accountHash = publicKey.toAccountHash();
     // prettier-ignore
     const validResult = Uint8Array.from([

--- a/src/lib/CLValue/PublicKey.ts
+++ b/src/lib/CLValue/PublicKey.ts
@@ -207,7 +207,7 @@ export class CLPublicKey extends CLValue implements CLKeyVariant<Uint8Array> {
     }
     if (!isChecksummed(publicKeyHex)) {
       console.warn(
-        'Provided public key is not checksummed. Please check if you provide valid public key. You can generate checksummed public key from CLPublicKey.toHex(true).'
+        'Provided public key is not checksummed. Please check if you provide valid public key. You can generate checksummed public key from CLPublicKey.toFormattedString(true).'
       );
       if (checksummed) throw Error('Provided public key is not checksummed.');
     }

--- a/src/lib/Contracts.ts
+++ b/src/lib/Contracts.ts
@@ -33,7 +33,8 @@ export class Contract {
   constructor(public casperClient?: CasperClient) {}
 
   /**
-   * Attaches an on-chain smart contract to this `Contract` object using its hexadecimal string typed hash. The contract hash must include the prefix "hash-"
+   * Attaches an on-chain smart contract to this `Contract` object using its hexadecimal string typed hash. The contract hash must include the prefix "hash-".
+   * Setting contract hash will imply that the contract endpoints need to by called by contract hash. You still can use `setContractName`, but `setContractHash` takes priority if both are used.
    * @param contractHash The hexadecimal smart contract hash, with the prefix "entity-contract-"
    * @param contractPackageHash The hexadecimal smart contract package hash, with the prefix "package-". This parameter is optional, and only used when there is event processing present.
    */

--- a/src/lib/DeployUtil.test.ts
+++ b/src/lib/DeployUtil.test.ts
@@ -397,7 +397,7 @@ describe('DeployUtil', () => {
 
   it('DeployUtil.UniqAddress should serialize and deserialize', () => {
     const recipientKey = Keys.Ed25519.new();
-    const hexAddress = recipientKey.publicKey.toHex();
+    const hexAddress = recipientKey.publicKey.toFormattedString();
     const transferId = '80172309';
     const transferIdHex = '0x04c75515';
 

--- a/src/lib/DeployUtil.ts
+++ b/src/lib/DeployUtil.ts
@@ -323,8 +323,8 @@ export class StoredContractByHash extends ExecutableDeployItemInternal {
   public args: RuntimeArgs;
 
   /**
-   * Constructs a `StoredContractByHash` object from the `Uint8Array` typed hash, entrypoint of the contract, and associated runtime arguments
-   * @param hash `Uint8Array` typed smart contract hash
+   * Constructs a `StoredContractByHash` object from the hash, entrypoint of the contract, and associated runtime arguments
+   * @param hash hash of the addressable entity of the contract
    * @param entryPoint An entrypoint of the smart contract
    * @param args The runtime arguments for interaction on the `entryPoint`
    */
@@ -748,7 +748,7 @@ export class ExecutableDeployItem implements ToBytes {
 
   /**
    * Creates a new `StoredContractByHash` object from a `Uint8Array` contract hash, entrypoint, and runtime arguments
-   * @param hash `Uint8Array` representation of a smart contract hash
+   * @param hash `string` representation of a smart contract addreassable entity hash
    * @param entryPoint Name of an entrypoint of the stored contract
    * @param args The runtime arguments for the new `StoredContractByHash` object
    * @returns A new `ExecutableDeployItem` created from a new `StoredContractByHash` object built using `hash`, `entryPoint` and `args`

--- a/src/lib/DeployUtil.ts
+++ b/src/lib/DeployUtil.ts
@@ -88,7 +88,7 @@ export class UniqAddress {
    * @returns string with the format "accountHex-transferIdHex"
    */
   toString(): string {
-    return `${this.publicKey.toHex()}-${this.transferId.toHexString()}`;
+    return `${this.publicKey.toFormattedString()}-${this.transferId.toHexString()}`;
   }
 
   /**
@@ -98,7 +98,7 @@ export class UniqAddress {
    */
   static fromString(value: string): UniqAddress {
     const [accountHex, transferHex] = value.split('-');
-    const publicKey = CLPublicKey.fromHex(accountHex);
+    const publicKey = CLPublicKey.fromFormattedString(accountHex);
     return UniqAddress.build(publicKey, transferHex);
   }
 }
@@ -108,10 +108,10 @@ export class UniqAddress {
 export class DeployHeader implements ToBytes {
   @jsonMember({
     serializer: (account: CLPublicKey) => {
-      return account.toHex();
+      return account.toFormattedString();
     },
     deserializer: (hexStr: string) => {
-      return CLPublicKey.fromHex(hexStr, false);
+      return CLPublicKey.fromFormattedString(hexStr, false);
     }
   })
   public account: CLPublicKey;
@@ -1333,7 +1333,7 @@ export const setSignature = (
   publicKey: CLPublicKey
 ): Deploy => {
   const approval = new Approval();
-  approval.signer = publicKey.toHex();
+  approval.signer = publicKey.toFormattedString();
   // TBD: Make sure it is proper
   if (publicKey.isEd25519()) {
     approval.signature = Keys.Ed25519.accountHex(sig);
@@ -1479,7 +1479,7 @@ export const validateDeploy = (deploy: Deploy): Result<Deploy, string> => {
   }
 
   const isProperlySigned = deploy.approvals.every(({ signer, signature }) => {
-    const pk = CLPublicKey.fromHex(signer, false);
+    const pk = CLPublicKey.fromFormattedString(signer, false);
     const signatureRaw = decodeBase16(signature.slice(2));
     return validateSignature(deploy.hash, signatureRaw, pk);
   });

--- a/src/lib/InitiatorAddr.ts
+++ b/src/lib/InitiatorAddr.ts
@@ -56,7 +56,7 @@ export class InitiatorAddr {
       };
     } else if (this.PublicKey) {
       return {
-        PublicKey: this.PublicKey.toHex()
+        PublicKey: this.PublicKey.toFormattedString()
       };
     }
     return undefined;
@@ -65,7 +65,9 @@ export class InitiatorAddr {
 
 export const matchInitiatorAddress = (json: any): InitiatorAddr | undefined => {
   if (json.PublicKey) {
-    return InitiatorAddr.fromPublicKey(CLPublicKey.fromHex(json.PublicKey));
+    return InitiatorAddr.fromPublicKey(
+      CLPublicKey.fromFormattedString(json.PublicKey)
+    );
   } else if (json.AccountHash) {
     return InitiatorAddr.fromAccountHash(
       CLAccountHash.fromFormattedString(json.AccountHash)

--- a/src/lib/Signer/CasperWallet.ts
+++ b/src/lib/Signer/CasperWallet.ts
@@ -196,7 +196,7 @@ export class CasperWallet extends BaseSigner {
       const signedDeploy = DeployUtil.setSignature(
         DeployUtil.deployFromJson(deploy).unwrap(),
         result.signature,
-        CLPublicKey.fromHex(signingPublicKey)
+        CLPublicKey.fromFormattedString(signingPublicKey)
       );
 
       return DeployUtil.deployToJson(signedDeploy);

--- a/src/lib/TransactionTarget.test.ts
+++ b/src/lib/TransactionTarget.test.ts
@@ -53,11 +53,10 @@ const expectedStoredVariantBytes = [
   0,
   0
 ];
-const expectedSessionVariantBytes = [2, 0, 4, 0, 0, 0, 81, 5, 6, 10, 0];
+const expectedSessionVariantBytes = [2, 4, 0, 0, 0, 81, 5, 6, 10, 0];
 const mockSessionJson = {
   a: {
     Session: {
-      kind: 'Standard',
       module_bytes: '5105060a',
       runtime: 'VmCasperV1'
     }

--- a/src/lib/TransactionUtil.test.ts
+++ b/src/lib/TransactionUtil.test.ts
@@ -39,7 +39,7 @@ describe('TransactionUtil', () => {
   const expectedBodyHash =
     '7d963698c7464204e91e1b1b4ead647a9e85e64dbf5573b2180216214d155724';
   it('should calculate body has correctly', () => {
-    CLPublicKey.fromHex(
+    CLPublicKey.fromFormattedString(
       '01ae0a8ba1e0d2c96eaa84de63d4051396147ed30aeba6919b01952c833e0814b8',
       false
     );

--- a/src/services/CasperServiceByJsonRPC.ts
+++ b/src/services/CasperServiceByJsonRPC.ts
@@ -717,7 +717,6 @@ export class CasperServiceByJsonRPC {
       'This method is deprecated and will be removed in the future release, please use transaction method instead.'
     );
     this.checkDeploySize(signedDeploy);
-
     const { checkApproval = false } = props ?? {};
     if (checkApproval && signedDeploy.approvals.length == 0) {
       throw new Error('Required signed deploy');

--- a/src/services/CasperServiceByJsonRPC.ts
+++ b/src/services/CasperServiceByJsonRPC.ts
@@ -146,6 +146,7 @@ export class CasperServiceByJsonRPC {
   /**
    * Constructor for building a `CasperServiceByJsonRPC`
    * @param provider A provider uri
+   * @param muffleDeprecationWarnings If set to `true`, deprecation warnings in this class will be suppressed. Defaults to `false`.
    */
   constructor(
     provider: string | SafeEventEmitterProvider,


### PR DESCRIPTION
Removing `TransactionSessionKind` since field `kind` was removed from `Session` implementation of `TransactionTarget`