### PR TITLE
Aligned casing for fromJSON and toJSON, updated type for chain name for utils

### DIFF
--- a/src/sse/event.ts
+++ b/src/sse/event.ts
@@ -114,14 +114,14 @@ export class RawEvent {
   parseAsTransactionProcessedEvent(): TransactionProcessedEvent {
     return this.parseEvent(
       TransactionProcessedEvent,
-      TransactionProcessedEvent.fromJson
+      TransactionProcessedEvent.fromJSON
     );
   }
 
   parseAsTransactionAcceptedEvent(): TransactionAcceptedEvent {
     return this.parseEvent(
       TransactionAcceptedEvent,
-      TransactionAcceptedEvent.fromJson
+      TransactionAcceptedEvent.fromJSON
     );
   }
 
@@ -340,7 +340,7 @@ export class TransactionAcceptedEvent {
   })
   transactionAcceptedPayload: TransactionAcceptedPayload;
 
-  public static fromJson(data: unknown): TransactionAcceptedEvent | Error {
+  public static fromJSON(data: unknown): TransactionAcceptedEvent | Error {
     try {
       const transactionEvent = TypedJSON.parse(data, TransactionAcceptedEvent);
       if (!transactionEvent) throw new Error('TransactionAcceptedEvent is nil');
@@ -475,7 +475,7 @@ export class TransactionProcessedEvent {
   })
   transactionProcessedPayload: TransactionProcessedPayload;
 
-  public static fromJson(data: any): TransactionProcessedEvent | Error {
+  public static fromJSON(data: any): TransactionProcessedEvent | Error {
     try {
       const transactionEvent = TypedJSON.parse(data, TransactionProcessedEvent);
       if (!transactionEvent)

--- a/src/types/Deploy.test.ts
+++ b/src/types/Deploy.test.ts
@@ -62,7 +62,7 @@ describe('Deploy', () => {
     await deploy.sign(senderKey);
     await deploy.sign(recipientKey);
 
-    const json = Deploy.toJson(deploy);
+    const json = Deploy.toJSON(deploy);
 
     deploy = Deploy.fromJSON(json);
 

--- a/src/types/Deploy.ts
+++ b/src/types/Deploy.ts
@@ -464,7 +464,7 @@ export class Deploy {
    * @param deploy The deploy object to convert to JSON.
    * @returns A JSON representation of the deploy.
    */
-  public static toJson = (deploy: Deploy) => {
+  public static toJSON = (deploy: Deploy) => {
     const serializer = new TypedJSON(Deploy);
     return serializer.toPlainJson(deploy);
   };

--- a/src/types/Transaction.ts
+++ b/src/types/Transaction.ts
@@ -265,7 +265,7 @@ export class TransactionV1 {
    * @param transaction The `TransactionV1` object.
    * @returns A JSON version of the `TransactionV1`.
    */
-  public static toJson = (transaction: TransactionV1) => {
+  public static toJSON = (transaction: TransactionV1) => {
     const serializer = new TypedJSON(TransactionV1);
 
     return serializer.toPlainJson(transaction);
@@ -550,7 +550,7 @@ export class Transaction {
     return Deploy.newTransactionFromDeploy(deploy);
   }
 
-  static fromJson(json: any): Transaction {
+  static fromJSON(json: any): Transaction {
     try {
       const txV1 = TransactionV1.fromJSON(json);
 

--- a/src/utils/cep-18-transfer.ts
+++ b/src/utils/cep-18-transfer.ts
@@ -7,19 +7,21 @@ import {
   Deploy,
   DeployHeader,
   Duration,
-  ExecutableDeployItem, Key, KeyTypeID,
+  ExecutableDeployItem,
+  Key,
+  KeyTypeID,
   PublicKey,
   StoredContractByHash
 } from '../types';
 import { CasperNetworkName } from '../@types';
 
 export interface IMakeCep18TransferDeployParams {
-  contractHash: string,
+  contractHash: string;
   senderPublicKeyHex: string;
   recipientPublicKeyHex: string;
   transferAmount: string;
-  paymentAmount: string,
-  chainName?: CasperNetworkName;
+  paymentAmount: string;
+  chainName?: string;
   ttl?: number;
 }
 
@@ -36,8 +38,7 @@ export interface IMakeCep18TransferDeployParams {
  *                                For example, to transfer 2.5 CSPR, provide the value `2500000000` (2.5 * 10^9 motes).
  * @param params.paymentAmount - The amount of CSPR to pay a network fee.
  *                               This value must be represented in its smallest unit (motes).
- * @param params.chainName - (Optional) The name of the Casper network chain - {CasperNetworkName}.
- *                           Must be either `'casper'` (mainnet) or `'casper-test'` (testnet).
+ * @param params.chainName - (Optional) The name of the Casper network chain.
  *                           Defaults to `'CasperNetworkName.Mainnet'` if not specified.
  * @param params.ttl - (Optional) The time-to-live (TTL) for the `Deploy` in milliseconds.
  *                      Specifies how long the `Deploy` is valid before it expires.
@@ -59,6 +60,7 @@ export interface IMakeCep18TransferDeployParams {
  * console.log('Created Deploy:', deploy);
  * ```
  */
+
 export const makeCep18TransferDeploy = ({
   contractHash,
   senderPublicKeyHex,
@@ -66,7 +68,7 @@ export const makeCep18TransferDeploy = ({
   transferAmount,
   paymentAmount,
   chainName = CasperNetworkName.Mainnet,
-  ttl = DEFAULT_DEPLOY_TTL,
+  ttl = DEFAULT_DEPLOY_TTL
 }: IMakeCep18TransferDeployParams): Deploy => {
   const senderPublicKey = PublicKey.newPublicKey(senderPublicKeyHex);
   const recipientPublicKey = PublicKey.newPublicKey(recipientPublicKeyHex);
@@ -77,7 +79,12 @@ export const makeCep18TransferDeploy = ({
     ContractHash.newContract(contractHash),
     'transfer',
     Args.fromMap({
-      recipient: CLValue.newCLKey(Key.createByType(recipientPublicKey.accountHash().toPrefixedString(), KeyTypeID.Account)),
+      recipient: CLValue.newCLKey(
+        Key.createByType(
+          recipientPublicKey.accountHash().toPrefixedString(),
+          KeyTypeID.Account
+        )
+      ),
       amount: CLValueUInt256.newCLUInt256(transferAmount)
     })
   );

--- a/src/utils/cep-nft-transfer.ts
+++ b/src/utils/cep-nft-transfer.ts
@@ -25,7 +25,7 @@ export interface IMakeNftTransferDeployParams {
   senderPublicKeyHex: string;
   recipientPublicKeyHex: string;
   paymentAmount: string;
-  chainName?: CasperNetworkName;
+  chainName?: string;
   ttl?: number;
   tokenId?: string;
   tokenHash?: string;

--- a/src/utils/cspr-transfer.ts
+++ b/src/utils/cspr-transfer.ts
@@ -13,7 +13,7 @@ export interface IMakeCsprTransferDeployParams {
   senderPublicKeyHex: string;
   recipientPublicKeyHex: string;
   transferAmount: string;
-  chainName?: CasperNetworkName;
+  chainName?: string;
   memo?: string;
   ttl?: number;
 }
@@ -29,8 +29,7 @@ export interface IMakeCsprTransferDeployParams {
  * @param params.transferAmount - The amount of CSPR to transfer.
  *                                This value must be represented in its smallest unit (motes).
  *                                For example, to transfer 2.5 CSPR, provide the value `2500000000` (2.5 * 10^9 motes).
- * @param params.chainName - (Optional) The name of the Casper network chain - {CasperNetworkName}.
- *                           Must be either `'casper'` (mainnet) or `'casper-test'` (testnet).
+ * @param params.chainName - (Optional) The name of the Casper network chain.
  *                           Defaults to `'CasperNetworkName.Mainnet'` if not specified.
  * @param params.memo - (Optional) Tag/Memo (Comment/Note/Remark)
  *                      Most exchanges require a Tag/Memo for CSPR deposits to be credited correctly.


### PR DESCRIPTION
- `chainName` accept any string. In addition to mainnet (`casper`) and testnet (`casper-test`), we may have other network names like casper-net-1 for NCTL or integration-test.
- Aligned casing for `fromJSON` and `toJSON`