### PR TITLE
Add TransferID to transaction/deploy

### DIFF
--- a/src/utils/casper-network.ts
+++ b/src/utils/casper-network.ts
@@ -184,7 +184,8 @@ export class CasperNetwork {
     networkName: string,
     amountMotes: string,
     deployCost: number,
-    ttl: number
+    ttl: number,
+    id: number
   ): Transaction {
     const transferBuilder = new NativeTransferBuilder()
       .from(senderPublicKey)
@@ -192,7 +193,8 @@ export class CasperNetwork {
       .amount(amountMotes)
       .chainName(networkName)
       .payment(deployCost)
-      .ttl(ttl);
+      .ttl(ttl)
+      .id(id);
     if (this.apiVersion === 2) {
       return transferBuilder.build();
     }


### PR DESCRIPTION
In cspr.live we need to provide a TransferdId memo and later we need to show it.

<img width="745" alt="image" src="https://github.com/user-attachments/assets/3d3cc6d4-aa0c-4368-8fa0-5b9b24bcbcf9" />
<img width="1111" alt="image" src="https://github.com/user-attachments/assets/4e856dd2-2f3e-4c9e-94c2-2e17d30baf50" />
