### PR TITLE
Resolve DEP0169 url.parse() deprecation and add ESM support

### DIFF
--- a/.github/workflows/ci-casper-client-sdk.yml
+++ b/.github/workflows/ci-casper-client-sdk.yml
@@ -61,7 +61,7 @@ jobs:
         run: npm run lint:ci
 
       - name: Unit Test
-        run: npm run test:node:unit
+        run: ${{ matrix.node-version == '22.x' && 'npm run test:node:unit:node22' || 'npm run test:node:unit' }}
 
       - name: Test build
         run: npm run build

--- a/.github/workflows/ci-casper-client-sdk.yml
+++ b/.github/workflows/ci-casper-client-sdk.yml
@@ -27,7 +27,7 @@ jobs:
       fail-fast: false
       matrix:
         # See supported Node.js release schedule at https://nodejs.org/en/about/releases/
-        node-version: [16.x, 18.x]
+        node-version: [18.x, 22.x]
         os: [ubuntu-22.04]
     runs-on: ${{ matrix.os }}
     env:

--- a/package-lock.json
+++ b/package-lock.json
@@ -16,7 +16,6 @@
         "@noble/ed25519": "^1.7.3",
         "@noble/hashes": "^1.2.0",
         "@noble/secp256k1": "^1.7.1",
-        "@open-rpc/client-js": "^1.8.1",
         "@scure/bip32": "^1.1.5",
         "@scure/bip39": "^1.2.0",
         "@types/ws": "^8.2.2",
@@ -91,6 +90,9 @@
         "webpack-bundle-analyzer": "^4.8.0",
         "webpack-cli": "^4.5.0",
         "webpack-node-externals": "^2.5.2"
+      },
+      "engines": {
+        "node": ">=18"
       }
     },
     "node_modules/@antfu/install-pkg": {
@@ -1675,17 +1677,6 @@
       },
       "engines": {
         "node": ">=12.0.0"
-      }
-    },
-    "node_modules/@open-rpc/client-js": {
-      "version": "1.8.1",
-      "resolved": "https://registry.npmjs.org/@open-rpc/client-js/-/client-js-1.8.1.tgz",
-      "integrity": "sha512-vV+Hetl688nY/oWI9IFY0iKDrWuLdYhf7OIKI6U1DcnJV7r4gAgwRJjEr1QVYszUc0gjkHoQJzqevmXMGLyA0g==",
-      "dependencies": {
-        "isomorphic-fetch": "^3.0.0",
-        "isomorphic-ws": "^5.0.0",
-        "strict-event-emitter-types": "^2.0.0",
-        "ws": "^7.0.0"
       }
     },
     "node_modules/@polka/url": {
@@ -11373,23 +11364,6 @@
         "node": ">=0.10.0"
       }
     },
-    "node_modules/isomorphic-fetch": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/isomorphic-fetch/-/isomorphic-fetch-3.0.0.tgz",
-      "integrity": "sha512-qvUtwJ3j6qwsF3jLxkZ72qCgjMysPzDfeV240JHiGZsANBYd+EEuu35v7dfrJ9Up0Ak07D7GGSkGhCHTqg/5wA==",
-      "dependencies": {
-        "node-fetch": "^2.6.1",
-        "whatwg-fetch": "^3.4.1"
-      }
-    },
-    "node_modules/isomorphic-ws": {
-      "version": "5.0.0",
-      "resolved": "https://registry.npmjs.org/isomorphic-ws/-/isomorphic-ws-5.0.0.tgz",
-      "integrity": "sha512-muId7Zzn9ywDsyXgTIafTry2sV3nySZeUDe6YedVd1Hvuuep5AsIlqK+XefWpYTyJG5e503F2xIuT2lcU6rCSw==",
-      "peerDependencies": {
-        "ws": "*"
-      }
-    },
     "node_modules/istanbul-lib-coverage": {
       "version": "3.2.2",
       "resolved": "https://registry.npmjs.org/istanbul-lib-coverage/-/istanbul-lib-coverage-3.2.2.tgz",
@@ -17164,11 +17138,6 @@
         "node": ">= 4.0.0"
       }
     },
-    "node_modules/strict-event-emitter-types": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/strict-event-emitter-types/-/strict-event-emitter-types-2.0.0.tgz",
-      "integrity": "sha512-Nk/brWYpD85WlOgzw5h173aci0Teyv8YdIAEtV+N88nDB0dLlazZyJMIsN6eo1/AR61l+p6CJTG1JIyFaoNEEA=="
-    },
     "node_modules/string_decoder": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
@@ -19498,11 +19467,6 @@
         "url": "https://opencollective.com/webpack"
       }
     },
-    "node_modules/whatwg-fetch": {
-      "version": "3.6.20",
-      "resolved": "https://registry.npmjs.org/whatwg-fetch/-/whatwg-fetch-3.6.20.tgz",
-      "integrity": "sha512-EqhiFU6daOA8kpjOWTL0olhVOF3i7OrFzSYiGsEMB8GcXS+RrzauAERX65xMeNWVqxA6HXH2m69Z9LaKKdisfg=="
-    },
     "node_modules/whatwg-url": {
       "version": "5.0.0",
       "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-5.0.0.tgz",
@@ -19709,6 +19673,7 @@
       "version": "7.5.10",
       "resolved": "https://registry.npmjs.org/ws/-/ws-7.5.10.tgz",
       "integrity": "sha512-+dbF1tHwZpXcbOJdVOkzLDxZP1ailvSxM6ZweXTegylPny803bFhA+vqBYw4s31NSAk4S2Qz+AKXK9a4wkdjcQ==",
+      "dev": true,
       "engines": {
         "node": ">=8.3.0"
       },

--- a/package-lock.json
+++ b/package-lock.json
@@ -3229,9 +3229,9 @@
       "integrity": "sha512-Rfkk/Mp/DL7JVje3u18FxFujQlTNR2q6QfMSMB7AvCBx91NGj/ba3kCfza0f6dVDbw7YlRf/nDrn7pQrCCyQ/w=="
     },
     "node_modules/@rollup/pluginutils/node_modules/picomatch": {
-      "version": "4.0.3",
-      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.3.tgz",
-      "integrity": "sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q==",
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.4.tgz",
+      "integrity": "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==",
       "engines": {
         "node": ">=12"
       },
@@ -4774,9 +4774,9 @@
       }
     },
     "node_modules/@vanilla-extract/compiler/node_modules/picomatch": {
-      "version": "4.0.3",
-      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.3.tgz",
-      "integrity": "sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q==",
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.4.tgz",
+      "integrity": "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==",
       "engines": {
         "node": ">=12"
       },
@@ -4858,9 +4858,9 @@
       }
     },
     "node_modules/@vanilla-extract/compiler/node_modules/yaml": {
-      "version": "2.8.2",
-      "resolved": "https://registry.npmjs.org/yaml/-/yaml-2.8.2.tgz",
-      "integrity": "sha512-mplynKqc1C2hTVYxd0PU2xQAc22TI1vShAYGksCCfxbn/dFwnHTNi1bvYsBTkhdUNtGIf5xNOg938rrSSYvS9A==",
+      "version": "2.8.3",
+      "resolved": "https://registry.npmjs.org/yaml/-/yaml-2.8.3.tgz",
+      "integrity": "sha512-AvbaCLOO2Otw/lW5bmh9d/WEdcDFdQp2Z2ZUH3pX9U2ihyUY0nvLv7J6TrWowklRGPYbB/IuIMfYgxaCPg5Bpg==",
       "optional": true,
       "peer": true,
       "bin": {
@@ -5952,9 +5952,9 @@
       }
     },
     "node_modules/brace-expansion": {
-      "version": "5.0.3",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.3.tgz",
-      "integrity": "sha512-fy6KJm2RawA5RcHkLa1z/ScpBeA762UF9KmZQxwIbDtRJrgLzM10depAiEQ+CXYcoiqW1/m96OAAoke2nE9EeA==",
+      "version": "5.0.5",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.5.tgz",
+      "integrity": "sha512-VZznLgtwhn+Mact9tfiwx64fA9erHH/MCXEUfB/0bX/6Fz6ny5EGTXYltMocqg4xFAQZtnO3DHWWXi8RiuN7cQ==",
       "dependencies": {
         "balanced-match": "^4.0.2"
       },
@@ -9413,9 +9413,9 @@
       }
     },
     "node_modules/flatted": {
-      "version": "3.3.3",
-      "resolved": "https://registry.npmjs.org/flatted/-/flatted-3.3.3.tgz",
-      "integrity": "sha512-GX+ysw4PBCz0PzosHDepZGANEuFCMLrnRTiEy9McGjmkCQYwRq4A/X786G/fjM/+OjsWSU1ZrY5qyARZmO/uwg==",
+      "version": "3.4.2",
+      "resolved": "https://registry.npmjs.org/flatted/-/flatted-3.4.2.tgz",
+      "integrity": "sha512-PjDse7RzhcPkIJwy5t7KPWQSZ9cAbzQXcafsetQoD7sOJRQlGikNbx7yZp2OotDnJyrDcbyRq3Ttb18iYOqkxA==",
       "dev": true
     },
     "node_modules/follow-redirects": {
@@ -9878,9 +9878,9 @@
       "integrity": "sha512-3GKBOn+m2LX9iq+JC1064cSFprJY4jL1jCXTcpnfER5HYE2l/4EfWSGzkPa/ZDBmYI0ZOEj5VHV/eKnPGkHuOg=="
     },
     "node_modules/handlebars": {
-      "version": "4.7.8",
-      "resolved": "https://registry.npmjs.org/handlebars/-/handlebars-4.7.8.tgz",
-      "integrity": "sha512-vafaFqs8MZkRrSX7sFVUdo3ap/eNiLnb4IakshzvP56X5Nr1iGKAIqdX6tMlm6HcNRIkr6AxO5jFEoJzzpT8aQ==",
+      "version": "4.7.9",
+      "resolved": "https://registry.npmjs.org/handlebars/-/handlebars-4.7.9.tgz",
+      "integrity": "sha512-4E71E0rpOaQuJR2A3xDZ+GM1HyWYv1clR58tC8emQNeQe3RH7MAzSbat+V0wG78LQBo6m6bzSG/L4pBuCsgnUQ==",
       "dev": true,
       "dependencies": {
         "minimist": "^1.2.5",
@@ -14860,9 +14860,9 @@
       "integrity": "sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA=="
     },
     "node_modules/picomatch": {
-      "version": "2.3.1",
-      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.3.1.tgz",
-      "integrity": "sha512-JU3teHTNjmE2VCGFzuY8EXzCDVwEqB2a8fsIvwaStHhAWJEeVd1o1QD80CU6+ZdEXXSLbSsuLwJjkCBWqRQUVA==",
+      "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.3.2.tgz",
+      "integrity": "sha512-V7+vQEJ06Z+c5tSye8S+nHUfI51xoXIXjHQ99cQtKUkQqqO1kO/KCJUfZXuB47h/YBlDhah2H3hdUGXn8ie0oA==",
       "dev": true,
       "engines": {
         "node": ">=8.6"
@@ -15861,9 +15861,9 @@
       }
     },
     "node_modules/remark-mdx-frontmatter/node_modules/yaml": {
-      "version": "2.8.2",
-      "resolved": "https://registry.npmjs.org/yaml/-/yaml-2.8.2.tgz",
-      "integrity": "sha512-mplynKqc1C2hTVYxd0PU2xQAc22TI1vShAYGksCCfxbn/dFwnHTNi1bvYsBTkhdUNtGIf5xNOg938rrSSYvS9A==",
+      "version": "2.8.3",
+      "resolved": "https://registry.npmjs.org/yaml/-/yaml-2.8.3.tgz",
+      "integrity": "sha512-AvbaCLOO2Otw/lW5bmh9d/WEdcDFdQp2Z2ZUH3pX9U2ihyUY0nvLv7J6TrWowklRGPYbB/IuIMfYgxaCPg5Bpg==",
       "bin": {
         "yaml": "bin.mjs"
       },
@@ -16889,9 +16889,9 @@
       }
     },
     "node_modules/socket.io-parser": {
-      "version": "4.2.5",
-      "resolved": "https://registry.npmjs.org/socket.io-parser/-/socket.io-parser-4.2.5.tgz",
-      "integrity": "sha512-bPMmpy/5WWKHea5Y/jYAP6k74A+hvmRCQaJuJB6I/ML5JZq/KfNieUVo/3Mh7SAqn7TyFdIo6wqYHInG1MU1bQ==",
+      "version": "4.2.6",
+      "resolved": "https://registry.npmjs.org/socket.io-parser/-/socket.io-parser-4.2.6.tgz",
+      "integrity": "sha512-asJqbVBDsBCJx0pTqw3WfesSY0iRX+2xzWEWzrpcH7L6fLzrhyF8WPI8UaeM4YCuDfpwA/cgsdugMsmtz8EJeg==",
       "dev": true,
       "dependencies": {
         "@socket.io/component-emitter": "~3.1.0",
@@ -17635,9 +17635,9 @@
       }
     },
     "node_modules/tinyglobby/node_modules/picomatch": {
-      "version": "4.0.3",
-      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.3.tgz",
-      "integrity": "sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q==",
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.4.tgz",
+      "integrity": "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==",
       "engines": {
         "node": ">=12"
       },
@@ -18511,9 +18511,9 @@
       }
     },
     "node_modules/vfile-matter/node_modules/yaml": {
-      "version": "2.8.2",
-      "resolved": "https://registry.npmjs.org/yaml/-/yaml-2.8.2.tgz",
-      "integrity": "sha512-mplynKqc1C2hTVYxd0PU2xQAc22TI1vShAYGksCCfxbn/dFwnHTNi1bvYsBTkhdUNtGIf5xNOg938rrSSYvS9A==",
+      "version": "2.8.3",
+      "resolved": "https://registry.npmjs.org/yaml/-/yaml-2.8.3.tgz",
+      "integrity": "sha512-AvbaCLOO2Otw/lW5bmh9d/WEdcDFdQp2Z2ZUH3pX9U2ihyUY0nvLv7J6TrWowklRGPYbB/IuIMfYgxaCPg5Bpg==",
       "bin": {
         "yaml": "bin.mjs"
       },
@@ -18590,9 +18590,9 @@
       }
     },
     "node_modules/vite-node/node_modules/picomatch": {
-      "version": "4.0.3",
-      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.3.tgz",
-      "integrity": "sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q==",
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.4.tgz",
+      "integrity": "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==",
       "engines": {
         "node": ">=12"
       },
@@ -18674,9 +18674,9 @@
       }
     },
     "node_modules/vite-node/node_modules/yaml": {
-      "version": "2.8.2",
-      "resolved": "https://registry.npmjs.org/yaml/-/yaml-2.8.2.tgz",
-      "integrity": "sha512-mplynKqc1C2hTVYxd0PU2xQAc22TI1vShAYGksCCfxbn/dFwnHTNi1bvYsBTkhdUNtGIf5xNOg938rrSSYvS9A==",
+      "version": "2.8.3",
+      "resolved": "https://registry.npmjs.org/yaml/-/yaml-2.8.3.tgz",
+      "integrity": "sha512-AvbaCLOO2Otw/lW5bmh9d/WEdcDFdQp2Z2ZUH3pX9U2ihyUY0nvLv7J6TrWowklRGPYbB/IuIMfYgxaCPg5Bpg==",
       "optional": true,
       "peer": true,
       "bin": {
@@ -18917,9 +18917,9 @@
       }
     },
     "node_modules/vocs/node_modules/picomatch": {
-      "version": "4.0.3",
-      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.3.tgz",
-      "integrity": "sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q==",
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.4.tgz",
+      "integrity": "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==",
       "engines": {
         "node": ">=12"
       },
@@ -19071,9 +19071,9 @@
       }
     },
     "node_modules/vocs/node_modules/yaml": {
-      "version": "2.8.2",
-      "resolved": "https://registry.npmjs.org/yaml/-/yaml-2.8.2.tgz",
-      "integrity": "sha512-mplynKqc1C2hTVYxd0PU2xQAc22TI1vShAYGksCCfxbn/dFwnHTNi1bvYsBTkhdUNtGIf5xNOg938rrSSYvS9A==",
+      "version": "2.8.3",
+      "resolved": "https://registry.npmjs.org/yaml/-/yaml-2.8.3.tgz",
+      "integrity": "sha512-AvbaCLOO2Otw/lW5bmh9d/WEdcDFdQp2Z2ZUH3pX9U2ihyUY0nvLv7J6TrWowklRGPYbB/IuIMfYgxaCPg5Bpg==",
       "bin": {
         "yaml": "bin.mjs"
       },
@@ -19714,9 +19714,9 @@
       "integrity": "sha512-a4UGQaWPH59mOXUYnAG2ewncQS4i4F43Tv3JoAM+s2VDAmS9NsK8GpDMLrCHPksFT7h3K6TOoUNn2pb7RoXx4g=="
     },
     "node_modules/yaml": {
-      "version": "1.10.2",
-      "resolved": "https://registry.npmjs.org/yaml/-/yaml-1.10.2.tgz",
-      "integrity": "sha512-r3vXyErRCYJ7wg28yvBY5VSoAF8ZvlcW9/BwUzEtUsjvX/DKs24dIkuwjtuprwJJHsbyUbLApepYTR1BN4uHrg==",
+      "version": "1.10.3",
+      "resolved": "https://registry.npmjs.org/yaml/-/yaml-1.10.3.tgz",
+      "integrity": "sha512-vIYeF1u3CjlhAFekPPAk2h/Kv4T3mAkMox5OymRiJQB0spDP10LHvt+K7G9Ny6NuuMAb25/6n1qyUjAcGNf/AA==",
       "dev": true,
       "engines": {
         "node": ">= 6"

--- a/package.json
+++ b/package.json
@@ -9,8 +9,17 @@
     "url": "https://github.com/casper-ecosystem/casper-js-sdk.git"
   },
   "main": "dist/lib.node.js",
+  "module": "dist/lib.esm.js",
   "browser": "dist/lib.web.js",
   "types": "dist/index.d.ts",
+  "exports": {
+    ".": {
+      "types": "./dist/index.d.ts",
+      "import": "./dist/lib.esm.js",
+      "require": "./dist/lib.node.js",
+      "default": "./dist/lib.node.js"
+    }
+  },
   "scripts": {
     "prepare": "husky-run install",
     "lint": "eslint src/ --fix",
@@ -31,6 +40,9 @@
     "docs:dev": "cd site && NODE_OPTIONS=--unhandled-rejections=none vocs dev",
     "docs:preview": "cd site && vocs preview",
     "prepublishOnly": "npm run build && npm run test:node:unit:node22"
+  },
+  "engines": {
+    "node": ">=18"
   },
   "keywords": [
     "Casper",
@@ -123,7 +135,6 @@
     "@noble/ed25519": "^1.7.3",
     "@noble/hashes": "^1.2.0",
     "@noble/secp256k1": "^1.7.1",
-    "@open-rpc/client-js": "^1.8.1",
     "@scure/bip32": "^1.1.5",
     "@scure/bip39": "^1.2.0",
     "@types/ws": "^8.2.2",

--- a/package.json
+++ b/package.json
@@ -125,7 +125,32 @@
     "elliptic": "^6.6.1",
     "minimatch": "^10.2.3",
     "bn.js": "^5.2.1",
-    "@types/d3-dispatch": "3.0.6"
+    "@types/d3-dispatch": "3.0.6",
+    "brace-expansion": "^5.0.5",
+    "@rollup/pluginutils": {
+      "picomatch": "^4.0.4"
+    },
+    "@vanilla-extract/compiler": {
+      "picomatch": "^4.0.4",
+      "yaml": "^2.8.3"
+    },
+    "tinyglobby": {
+      "picomatch": "^4.0.4"
+    },
+    "vite-node": {
+      "picomatch": "^4.0.4",
+      "yaml": "^2.8.3"
+    },
+    "vocs": {
+      "picomatch": "^4.0.4",
+      "yaml": "^2.8.3"
+    },
+    "remark-mdx-frontmatter": {
+      "yaml": "^2.8.3"
+    },
+    "vfile-matter": {
+      "yaml": "^2.8.3"
+    }
   },
   "dependencies": {
     "@ethersproject/bignumber": "^5.0.8",

--- a/package.json
+++ b/package.json
@@ -9,13 +9,13 @@
     "url": "https://github.com/casper-ecosystem/casper-js-sdk.git"
   },
   "main": "dist/lib.node.js",
-  "module": "dist/lib.esm.js",
+  "module": "dist/lib.esm.mjs",
   "browser": "dist/lib.web.js",
   "types": "dist/index.d.ts",
   "exports": {
     ".": {
       "types": "./dist/index.d.ts",
-      "import": "./dist/lib.esm.js",
+      "import": "./dist/lib.esm.mjs",
       "require": "./dist/lib.node.js",
       "default": "./dist/lib.node.js"
     }
@@ -33,6 +33,7 @@
     "test:node:unit:coverage": "nyc npm run test:node:unit",
     "test:browser:unit": "cross-env NODE_ENV=test karma start karma.conf.js --single-run",
     "test:unit": "cross-env NODE_ENV=test npm run test:node:unit && npm run test:browser:unit",
+    "test:esm:smoke": "node ./scripts/esm-smoke-test.mjs",
     "test:node:e2e": "cross-env NODE_ENV=test TS_NODE_FILES=true mocha -r ts-node/register \"e2e/**/*.test.ts\" --timeout 5000000 --exit",
     "test:e2e": "cross-env NODE_ENV=test npm run test:node:e2e",
     "test": "npm run test:unit && npm run test:e2e",

--- a/scripts/esm-smoke-test.mjs
+++ b/scripts/esm-smoke-test.mjs
@@ -1,0 +1,45 @@
+import assert from 'node:assert/strict';
+import { existsSync } from 'node:fs';
+import path from 'node:path';
+import { fileURLToPath, pathToFileURL } from 'node:url';
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = path.dirname(__filename);
+const repoRoot = path.resolve(__dirname, '..');
+const distEsmPath = path.join(repoRoot, 'dist', 'lib.esm.mjs');
+
+if (!existsSync(distEsmPath)) {
+  throw new Error(
+    'Missing dist/lib.esm.mjs. Run "npm run build" before the ESM smoke test.'
+  );
+}
+
+const builtModule = await import(pathToFileURL(distEsmPath).href);
+const packageModule = await import('casper-js-sdk');
+
+assert.ok(
+  Object.keys(builtModule).length > 0,
+  'Built ESM artifact exported no symbols.'
+);
+assert.ok(
+  Object.keys(packageModule).length > 0,
+  'Package export path exported no symbols.'
+);
+assert.equal(
+  packageModule.HttpHandler,
+  builtModule.HttpHandler,
+  'Package import does not resolve to the ESM build.'
+);
+
+const handler = new packageModule.HttpHandler(
+  'http://localhost:7777/rpc',
+  'fetch'
+);
+
+assert.equal(
+  typeof handler.processCall,
+  'function',
+  'HttpHandler smoke check failed.'
+);
+
+console.log('ESM smoke test passed.');

--- a/src/rpc/http_handler.ts
+++ b/src/rpc/http_handler.ts
@@ -28,7 +28,7 @@ export class HttpHandler implements IHandler {
     this.endpoint = endpoint;
     this.client = client;
     if (client === 'axios') {
-      this.httpClient = axios.create();
+      this.httpClient = axios.create({ adapter: 'fetch' });
     }
   }
 
@@ -91,8 +91,9 @@ export class HttpHandler implements IHandler {
   }
 
   private async processFetchRequest(body: string): Promise<RpcResponse> {
+    let response: Response;
     try {
-      const response = await fetch(this.endpoint, {
+      response = await fetch(this.endpoint, {
         method: 'POST',
         ...(this.referrer ? { referrer: this.referrer } : {}),
         headers: {
@@ -101,16 +102,16 @@ export class HttpHandler implements IHandler {
         },
         body
       });
-
-      if (response.status < 200 || response.status >= 300) {
-        throw new HttpError(response.status, new Error(response.statusText));
-      }
-
-      return response.json();
     } catch (err) {
       throw new Error(
         `${ErrProcessHttpRequest.message}, details: ${err.message}`
       );
     }
+
+    if (response.status < 200 || response.status >= 300) {
+      throw new HttpError(response.status, new Error(response.statusText));
+    }
+
+    return response.json();
   }
 }

--- a/src/tests/rpc/http_handler.test.ts
+++ b/src/tests/rpc/http_handler.test.ts
@@ -1,0 +1,269 @@
+import { expect } from 'chai';
+import sinon from 'sinon';
+
+import {
+  HttpHandler,
+  ErrProcessHttpRequest,
+  HttpError,
+  RpcRequest,
+  Method
+} from '../../rpc';
+
+describe('HttpHandler', () => {
+  const endpoint = 'http://localhost:7777/rpc';
+  const mockRpcResponse = {
+    jsonrpc: '2.0',
+    id: '1',
+    result: { api_version: '1.0' }
+  };
+  const mockRequest = RpcRequest.defaultRpcRequest(Method.GetStatus, {});
+
+  let fetchStub: sinon.SinonStub;
+
+  beforeEach(() => {
+    fetchStub = sinon.stub(global, 'fetch');
+  });
+
+  afterEach(() => {
+    sinon.restore();
+  });
+
+  describe('constructor', () => {
+    it('should default to axios client', () => {
+      const handler = new HttpHandler(endpoint);
+      expect((handler as any).client).to.equal('axios');
+    });
+
+    it('should accept fetch as explicit client', () => {
+      const handler = new HttpHandler(endpoint, 'fetch');
+      expect((handler as any).client).to.equal('fetch');
+    });
+
+    it('should create an axios instance when client is axios', () => {
+      const handler = new HttpHandler(endpoint, 'axios');
+      expect((handler as any).httpClient).to.not.be.undefined;
+    });
+
+    it('should not create an axios instance when client is fetch', () => {
+      const handler = new HttpHandler(endpoint, 'fetch');
+      expect((handler as any).httpClient).to.be.undefined;
+    });
+  });
+
+  describe('setCustomHeaders', () => {
+    it('should store custom headers', () => {
+      const handler = new HttpHandler(endpoint);
+      handler.setCustomHeaders({ 'X-Custom-Header': 'value' });
+      expect((handler as any).customHeaders).to.deep.equal({
+        'X-Custom-Header': 'value'
+      });
+    });
+  });
+
+  describe('setReferrer', () => {
+    it('should store referrer', () => {
+      const handler = new HttpHandler(endpoint);
+      handler.setReferrer('http://referrer.example.com');
+      expect((handler as any).referrer).to.equal('http://referrer.example.com');
+    });
+  });
+
+  describe('processCall — fetch client', () => {
+    it('should return the response body on success', async () => {
+      fetchStub.resolves(
+        new Response(JSON.stringify(mockRpcResponse), { status: 200 })
+      );
+
+      const handler = new HttpHandler(endpoint, 'fetch');
+      const result = await handler.processCall(mockRequest);
+
+      expect(result).to.deep.equal(mockRpcResponse);
+    });
+
+    it('should send a POST request to the configured endpoint', async () => {
+      fetchStub.resolves(
+        new Response(JSON.stringify(mockRpcResponse), { status: 200 })
+      );
+
+      const handler = new HttpHandler(endpoint, 'fetch');
+      await handler.processCall(mockRequest);
+
+      expect(fetchStub.calledOnce).to.be.true;
+      expect(fetchStub.firstCall.args[0]).to.equal(endpoint);
+      expect(fetchStub.firstCall.args[1].method).to.equal('POST');
+    });
+
+    it('should include Content-Type header', async () => {
+      fetchStub.resolves(
+        new Response(JSON.stringify(mockRpcResponse), { status: 200 })
+      );
+
+      const handler = new HttpHandler(endpoint, 'fetch');
+      await handler.processCall(mockRequest);
+
+      expect(fetchStub.firstCall.args[1].headers['Content-Type']).to.equal(
+        'application/json'
+      );
+    });
+
+    it('should include custom headers in the request', async () => {
+      fetchStub.resolves(
+        new Response(JSON.stringify(mockRpcResponse), { status: 200 })
+      );
+
+      const handler = new HttpHandler(endpoint, 'fetch');
+      handler.setCustomHeaders({ 'X-Api-Key': 'secret' });
+      await handler.processCall(mockRequest);
+
+      expect(fetchStub.firstCall.args[1].headers['X-Api-Key']).to.equal(
+        'secret'
+      );
+    });
+
+    it('should include referrer in the request when set', async () => {
+      fetchStub.resolves(
+        new Response(JSON.stringify(mockRpcResponse), { status: 200 })
+      );
+
+      const handler = new HttpHandler(endpoint, 'fetch');
+      handler.setReferrer('http://referrer.example.com');
+      await handler.processCall(mockRequest);
+
+      expect(fetchStub.firstCall.args[1].referrer).to.equal(
+        'http://referrer.example.com'
+      );
+    });
+
+    it('should not include referrer when not set', async () => {
+      fetchStub.resolves(
+        new Response(JSON.stringify(mockRpcResponse), { status: 200 })
+      );
+
+      const handler = new HttpHandler(endpoint, 'fetch');
+      await handler.processCall(mockRequest);
+
+      expect(fetchStub.firstCall.args[1].referrer).to.be.undefined;
+    });
+
+    it('should throw HttpError on 4xx response', async () => {
+      fetchStub.resolves(
+        new Response('Not Found', { status: 404, statusText: 'Not Found' })
+      );
+
+      const handler = new HttpHandler(endpoint, 'fetch');
+
+      try {
+        await handler.processCall(mockRequest);
+        expect.fail('Expected HttpError to be thrown');
+      } catch (err) {
+        expect(HttpError.isHttpError(err)).to.be.true;
+        expect((err as HttpError).statusCode).to.equal(404);
+      }
+    });
+
+    it('should throw HttpError on 5xx response', async () => {
+      fetchStub.resolves(
+        new Response('Internal Server Error', {
+          status: 500,
+          statusText: 'Internal Server Error'
+        })
+      );
+
+      const handler = new HttpHandler(endpoint, 'fetch');
+
+      try {
+        await handler.processCall(mockRequest);
+        expect.fail('Expected HttpError to be thrown');
+      } catch (err) {
+        expect(HttpError.isHttpError(err)).to.be.true;
+        expect((err as HttpError).statusCode).to.equal(500);
+      }
+    });
+
+    it('should throw a generic Error on network failure', async () => {
+      fetchStub.rejects(new TypeError('Failed to fetch'));
+
+      const handler = new HttpHandler(endpoint, 'fetch');
+
+      try {
+        await handler.processCall(mockRequest);
+        expect.fail('Expected Error to be thrown');
+      } catch (err) {
+        expect(HttpError.isHttpError(err)).to.be.false;
+        expect((err as Error).message).to.include(
+          ErrProcessHttpRequest.message
+        );
+      }
+    });
+  });
+
+  describe('processCall — axios client', () => {
+    it('should return the response body on success', async () => {
+      fetchStub.resolves(
+        new Response(JSON.stringify(mockRpcResponse), { status: 200 })
+      );
+
+      const handler = new HttpHandler(endpoint, 'axios');
+      const result = await handler.processCall(mockRequest);
+
+      expect(result).to.deep.equal(mockRpcResponse);
+    });
+
+    it('should throw HttpError on 4xx response', async () => {
+      fetchStub.resolves(
+        new Response('Not Found', { status: 404, statusText: 'Not Found' })
+      );
+
+      const handler = new HttpHandler(endpoint, 'axios');
+
+      try {
+        await handler.processCall(mockRequest);
+        expect.fail('Expected HttpError to be thrown');
+      } catch (err) {
+        expect(HttpError.isHttpError(err)).to.be.true;
+        expect((err as HttpError).statusCode).to.equal(404);
+      }
+    });
+
+    it('should throw HttpError on 5xx response', async () => {
+      fetchStub.resolves(
+        new Response('Internal Server Error', {
+          status: 500,
+          statusText: 'Internal Server Error'
+        })
+      );
+
+      const handler = new HttpHandler(endpoint, 'axios');
+
+      try {
+        await handler.processCall(mockRequest);
+        expect.fail('Expected HttpError to be thrown');
+      } catch (err) {
+        expect(HttpError.isHttpError(err)).to.be.true;
+        expect((err as HttpError).statusCode).to.equal(500);
+      }
+    });
+
+    it('should throw a generic Error on network failure', async () => {
+      fetchStub.rejects(new TypeError('Failed to fetch'));
+
+      const handler = new HttpHandler(endpoint, 'axios');
+
+      try {
+        await handler.processCall(mockRequest);
+        expect.fail('Expected Error to be thrown');
+      } catch (err) {
+        expect(HttpError.isHttpError(err)).to.be.false;
+        expect((err as Error).message).to.include(
+          ErrProcessHttpRequest.message
+        );
+      }
+    });
+
+    it('should use the fetch adapter (no follow-redirects dependency)', () => {
+      const handler = new HttpHandler(endpoint, 'axios');
+      const axiosInstance = (handler as any).httpClient;
+      expect(axiosInstance.defaults.adapter).to.equal('fetch');
+    });
+  });
+});

--- a/src/types/Bid.ts
+++ b/src/types/Bid.ts
@@ -242,7 +242,7 @@ export class VestingSchedule {
   /**
    * The list of locked amounts associated with this vesting schedule.
    */
-  @jsonArrayMember(CLValueUInt512, {
+  @jsonArrayMember(() => CLValueUInt512, {
     name: 'locked_amounts',
     serializer: (value: CLValueUInt512[]) => value.map(it => it.toJSON()),
     deserializer: (json: any) =>

--- a/src/types/TransactionTarget.ts
+++ b/src/types/TransactionTarget.ts
@@ -1,4 +1,4 @@
-import isNull from 'lodash/isNull';
+import isNull from 'lodash/isNull.js';
 import { BigNumber } from '@ethersproject/bignumber';
 import { concat } from '@ethersproject/bytes';
 

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -1,8 +1,8 @@
 const path = require('path');
 const copyPlugin = require('copy-webpack-plugin');
 const webpack = require('webpack');
-const BundleAnalyzerPlugin =
-  require('webpack-bundle-analyzer').BundleAnalyzerPlugin;
+const BundleAnalyzerPlugin = require('webpack-bundle-analyzer')
+  .BundleAnalyzerPlugin;
 const nodeExternals = require('webpack-node-externals');
 
 /** @type { import('webpack').Configuration } */
@@ -94,4 +94,27 @@ const bundlerConfig = {
 };
 
 /** @type { import('webpack').Configuration } */
-module.exports = [serverConfig, clientConfig, bundlerConfig];
+const esmConfig = {
+  ...common,
+  target: 'node',
+  experiments: {
+    outputModule: true
+  },
+  // BundleAnalyzerPlugin has known issues with outputModule: true — exclude it
+  plugins: [],
+  externals: [nodeExternals()],
+  externalsPresets: {
+    node: true
+  },
+  output: {
+    path: path.resolve(__dirname, 'dist'),
+    filename: 'lib.esm.js',
+    chunkFormat: 'module',
+    library: {
+      type: 'module'
+    }
+  }
+};
+
+/** @type { import('webpack').Configuration } */
+module.exports = [serverConfig, clientConfig, bundlerConfig, esmConfig];

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -97,18 +97,37 @@ const bundlerConfig = {
 const esmConfig = {
   ...common,
   target: 'node',
+  externalsType: 'module',
+  module: {
+    rules: [
+      {
+        test: /\.ts?$/,
+        use: {
+          loader: 'ts-loader',
+          options: {
+            configFile: 'tsconfig.build.json',
+            compilerOptions: {
+              module: 'esnext',
+              moduleResolution: 'node'
+            }
+          }
+        },
+        exclude: /node_modules/
+      }
+    ]
+  },
   experiments: {
     outputModule: true
   },
   // BundleAnalyzerPlugin has known issues with outputModule: true — exclude it
   plugins: [],
-  externals: [nodeExternals()],
+  externals: [nodeExternals({ importType: 'module' })],
   externalsPresets: {
     node: true
   },
   output: {
     path: path.resolve(__dirname, 'dist'),
-    filename: 'lib.esm.js',
+    filename: 'lib.esm.mjs',
     chunkFormat: 'module',
     library: {
       type: 'module'


### PR DESCRIPTION
- **Removed unused `@open-rpc/client-js` dependency**
  - Its compiled mock invoked `url.parse()`, triggering `DEP0169` warnings during test runs  

- **Switched Axios to the built-in `fetch` adapter (`adapter: 'fetch'`)**
  - Bypasses `follow-redirects`, which was calling `url.parse()` on every RPC request  

- **Fixed `HttpError` being swallowed in `processFetchRequest`**
  - Moved the status check outside the `try/catch` so errors propagate correctly to callers  

- **Added Webpack ESM build target (`lib.esm.js`)**
  - Uses `experiments.outputModule`  

- **Updated `package.json`**
  - Added `"exports"` and `"module"` fields for proper ESM/CJS resolution  
  - Fixes named imports in modern TypeScript projects  

- **Added `"engines": { "node": ">=18" }`**
  - Reflects the requirement for the `fetch` adapter  

- **Added unit tests for `HttpHandler`**
  - Covers both Axios and fetch client paths  


- <ins>Resolves</ins>: https://github.com/casper-ecosystem/casper-js-sdk/issues/595
- <ins>Resolves</ins>: https://github.com/casper-ecosystem/casper-js-sdk/issues/567