### PR TITLE
Add react-native and browser exports conditions

### DIFF
--- a/package.json
+++ b/package.json
@@ -15,6 +15,8 @@
   "exports": {
     ".": {
       "types": "./dist/index.d.ts",
+      "react-native": "./dist/lib.web.js",
+      "browser": "./dist/lib.web.js",
       "import": "./dist/lib.esm.mjs",
       "require": "./dist/lib.node.js",
       "default": "./dist/lib.node.js"


### PR DESCRIPTION
## Summary
- Adds `react-native` and `browser` conditions to the `exports` field in `package.json`, mapped to `./dist/lib.web.js`.
- Fixes resolution under Metro (React Native 0.85+) and web bundlers that honor Package Exports, which previously fell through to the Node build and pulled in Node core modules unavailable in those environments.
- Conditions are placed above `import`/`require`/`default` so conditional resolution matches them first.