### PR TITLE
Fix the npm publish workflow

### DIFF
--- a/.github/workflows/publish-casper-client-sdk.yml
+++ b/.github/workflows/publish-casper-client-sdk.yml
@@ -5,17 +5,102 @@ on:
     tags:
       - '*.*.*'
 
-permissions:
-  contents: write
-  id-token: write
+concurrency:
+  group: publish-${{ github.ref_name }}
+  cancel-in-progress: false # never cancel a run that may already have published
 
 jobs:
-  publish:
+  verify:
     runs-on: ubuntu-24.04
 
-    strategy:
-      matrix:
-        node-version: [22.x]
+    permissions:
+      contents: read
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6
+        with:
+          fetch-depth: 0 # needed for `git describe` (previous tag) and the dev-ancestry guard
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v6
+        with:
+          node-version: 22.x
+          cache: 'npm'
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Verify the tag sits on dev
+        run: |
+          git fetch --no-tags origin dev
+          git merge-base --is-ancestor "$GITHUB_SHA" origin/dev \
+            || { echo "::error::tag ${GITHUB_REF_NAME} is not an ancestor of dev"; exit 1; }
+
+      - name: Pre-flight
+        run: |
+          # 1. the tag must match the version actually being published.
+          #    npm publishes package.json's `version`, NOT the tag — there is no link between them.
+          pkg=$(node -p "require('./package.json').version")
+          [ "$pkg" = "$GITHUB_REF_NAME" ] \
+            || { echo "::error::tag $GITHUB_REF_NAME != package.json version $pkg"; exit 1; }
+
+          # 2. fail fast if the version is already on npm, instead of burning a full
+          #    build + prepublishOnly test run only to hit EPUBLISHCONFLICT (403) at the end.
+          #    `npm view pkg@version` exits 0 when it exists and exits 1 (E404) when it does not,
+          #    so it MUST be wrapped in `if`, or GitHub's `bash -e` kills the step on the healthy path.
+          if npm view "casper-js-sdk@$GITHUB_REF_NAME" version >/dev/null 2>&1; then
+            echo "::error::casper-js-sdk@$GITHUB_REF_NAME is already published"; exit 1
+          fi
+
+      - name: Build
+        run: npm run build
+
+      - name: Extract release notes from CHANGELOG
+        env:
+          GH_TOKEN: ${{ github.token }} # for the `gh api` contributor lookup below
+        run: |
+          awk -v v="$GITHUB_REF_NAME" '
+            $0 ~ "^### \\[" v "\\]" { on = 1; next }
+            on && /^### \[[0-9]/     { exit }
+            on                       { print }
+          ' CHANGELOG.md > RELEASE_NOTES.md
+          test -s RELEASE_NOTES.md \
+            || { echo "::error::no CHANGELOG.md entry for $GITHUB_REF_NAME"; exit 1; }
+          prev=$(git describe --tags --abbrev=0 "$GITHUB_REF_NAME^") || prev=''
+          if [ -n "$prev" ]; then
+            printf '\n\n**Full Changelog**: %s/compare/%s...%s\n' \
+              "$GITHUB_SERVER_URL/$GITHUB_REPOSITORY" "$prev" "$GITHUB_REF_NAME" >> RELEASE_NOTES.md
+            contributors=$(gh api "repos/$GITHUB_REPOSITORY/compare/$prev...$GITHUB_REF_NAME" \
+              --jq '.commits[].author.login // empty' \
+              | grep -v '\[bot\]$' | sort -u \
+              | awk '{ printf "%s@%s", (NR > 1 ? ", " : ""), $0 }')   # NOT `paste -sd', '`: paste
+                                                                     # cycles its delimiter list and
+                                                                     # emits `a,b c` for 3+ entries
+            # `if`, not `[ … ] && printf`: as the trailing statement of a `bash -e` script the
+            # latter exits 1 when there is no linked author to credit, failing an otherwise fine step.
+            if [ -n "$contributors" ]; then
+              printf '\n**Contributors**: %s\n' "$contributors" >> RELEASE_NOTES.md
+            fi
+          fi
+
+      - name: Upload build artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: publish-artifacts
+          path: |
+            dist/
+            RELEASE_NOTES.md
+          retention-days: 1
+
+  publish:
+    needs: verify
+    runs-on: ubuntu-24.04
+    environment: npm-publish
+
+    permissions:
+      contents: write
+      id-token: write
 
     steps:
       - name: Checkout
@@ -24,7 +109,7 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@v6
         with:
-          node-version: ${{ matrix.node-version }}
+          node-version: 22.x
           registry-url: 'https://registry.npmjs.org'
           cache: 'npm'
 
@@ -36,8 +121,10 @@ jobs:
       - name: Install dependencies
         run: npm ci
 
-      - name: Build
-        run: npm run build
+      - name: Download build artifact
+        uses: actions/download-artifact@v4
+        with:
+          name: publish-artifacts
 
       - name: Publish to npm
         run: npm publish --access public --tag latest
@@ -48,6 +135,7 @@ jobs:
       - name: Create GitHub Release
         uses: softprops/action-gh-release@v2
         with:
-          generate_release_notes: true
+          name: Casper JS SDK v${{ github.ref_name }}
+          body_path: RELEASE_NOTES.md
           files: |
             casper-js-sdk.v${{ github.ref_name }}.js


### PR DESCRIPTION
`.github/workflows/publish-casper-client-sdk.yml` had four independent defects. None of them affected the *content* of what was published — the `5.0.12` and `5.0.13` npm packages and their attached assets are correct — but together they meant a release could go out with wrong notes, under the wrong version, from any branch, with nobody approving it.

**Release notes came from a commit range that is wrong by construction.** Tags point at release-branch tips rather than at the merge commit on `dev`, so `generate_release_notes` diffed a range that included the *previous* release's merge commit and excluded the current one. The `5.0.13` body ended up advertising the previous version's PR and listing none of its own changes. The body now comes from the hand-written `CHANGELOG.md` section, which is verbatim what every release ≤ `5.0.12` carried anyway.

**The release was titled with the raw tag** (`5.0.13`) instead of `Casper JS SDK v5.0.13`, the convention every earlier release followed.

**The contributor avatar block is a side effect of `@mentions` in the body**, not a separate API field, so moving to a CHANGELOG-derived body would silently drop attribution. A `**Contributors**:` line and a Full Changelog link are appended from the tag-to-tag compare. Authors whose commit email is not linked to a GitHub account are omitted rather than errored on.

**Every check ran after `npm publish`.** Four gates now sit ahead of it: the tagged commit must be an ancestor of `dev`, the tag must equal `package.json.version`, the version must not already be on npm, and the extracted CHANGELOG section must be non-empty. The version check is the one with real exposure — npm publishes `package.json`'s `version`, not the tag, and at the time of the audit `package.json` said `5.1.0` while the newest tag was `5.0.13`.

**Nothing human stood between a tag push and npm.** The job is split into `verify` → `publish`, with `environment: npm-publish` on the second, so the run pauses for a reviewer *after* the checks are green rather than before checkout. The cost is that `dist/` and `RELEASE_NOTES.md` travel via an artifact and the publish job needs its own `npm ci`.

A workflow-level `concurrency` group with `cancel-in-progress: false` is added so a run that may already have published is never cancelled.

### Repo settings applied alongside this

These cannot be delivered by a PR, and the `environment:` line is inert without them:

- Environment `npm-publish` with required reviewers and `can_admins_bypass: false`.
- Tag ruleset on `*.*.*`: creations restricted to the Repository admin and Maintain roles, and the tag name must match `^\d+\.\d+\.\d+(-[0-9A-Za-z.-]+)?$`.

### Tagging procedure this depends on

Create the release tag from `dev` after the release PR lands, never from the release-branch tip — otherwise the ancestry gate fails the publish.

### Verification

Checked against the real `CHANGELOG.md`: extraction for an existing version yields that section only, stopping at the next version heading and not at the `### Changed` / `### Removed` sub-headings; a version with no section produces an empty file and fails the step; the previous-tag lookup resolves `5.0.13^` to `5.0.12`; the contributor join emits `@a, @b` correctly for three or more entries and filters bots; and `git merge-base --is-ancestor 5.0.13 dev` returns non-zero, i.e. the new ancestry gate would have caught the exact defect that produced the bad `5.0.13` notes.

Not verifiable from a file, and left for the `5.1.0` release itself: that the run actually pauses on `publish`, that the artifact round-trip feeds `Rename package` and `body_path`, and that the release page renders the title, CHANGELOG body and Contributors block.

### Known residual

A tag like `5.1` matches neither the ruleset condition nor the workflow's `*.*.*` trigger, so it is silently ignored — no publish, no error. Closing that would mean scoping the ruleset to all tags and thereby blocking non-release tags for everyone below the Maintain role.

<sub>Stack created with <a href="https://github.com/github/gh-stack">GitHub Stacks CLI</a> • <a href="https://gh.io/stacks-feedback">Give Feedback 💬</a></sub>
