### PR TITLE
Date the 5.1.0 changelog entry to its release day

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,7 +13,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
   ### Removed
  -->
 
-### [5.1.0] - 2026-08-07
+### [5.1.0] - 2026-08-11
 
 No runtime or API change — `dist/` behaves exactly as in `5.0.13` and `engines.node` stays `">=18"`. The rest of the release is an internal toolchain update with no effect on consumers.
 


### PR DESCRIPTION
The `### [5.1.0]` section was written on 2026-08-07, but the tag ships on 2026-08-11. The publish workflow extracts the GitHub Release body from this section verbatim, so the date in the changelog is also the date consumers see on the release.

Top of the stack: merges after #607.